### PR TITLE
Repair reset from "More tutorials" to "Submit" btn - closes #118

### DIFF
--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -90,7 +90,7 @@
             </div>
           </div>
           <div class="pt3 ph2 tr">
-            <div v-if="((output.test && output.test.success) || lessonPassed) && lessonNumber === lessonsInWorkshop">
+            <div v-if="lessonPassed && (lessonNumber === lessonsInWorkshop)">
               <Button v-bind:click="workshopMenu" class="bg-aqua white">More Tutorials</Button>
             </div>
             <div v-else-if="lessonPassed">


### PR DESCRIPTION
- Update conditional for "More tutorials" button so that when you click
to "Reset code" the button will return to the "Submit" state and stay
that way until correct code is submitted again.
- Previously the code allowed the button to appear as "More Tutorials"
if `output.test.success` were still true. Now `lessonPassed` must always
be true, as that field is updated to be false when you reset the code.