### PR TITLE
Add license 

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,29 @@
+# License
+
+ProtoSchool is licensed under both the Apache 2.0 and MIT licenses, as noted below.
+
+## Apache License, Version 2.0
+
+Copyright 2019 Protocol Labs
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## MIT License
+
+Copyright 2019 Protocol Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -95,3 +95,7 @@ the sample code failed in order to help the user along.
 Code is a string property. It's the sample code used to populate the code
 editor. If not set there's a default, used in the first lesson, that is used
 instead.
+
+## License
+
+ProtoSchool is licensed under the Apache-2.0 and MIT licenses. See [LICENSE.md](https://github.com/protoschool/protoschool.github.io/blob/master/LICENSE.md) for further detail.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# proto.school
+# ProtoSchool
 
-If you're just interested in doing the tutorials, visit https://proto.school.
+ProtoSchool is an educational community that teaches decentralized web protocols and tools
+through online tutorials and local chapter events.
+
+This repository is for the main ProtoSchool website, hosted at https://proto.school, where you can
+explore our self-guided interactive tutorials.
+
+For information on local chapter organizing, please visit our [organizing repo](https://github.com/protoschool/organizing)
 
 If you're interested in building tutorials, keep reading!
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "protoschool",
   "version": "1.0.0",
+  "license": "Apache-2.0 AND MIT",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
Partially addresses #130, although we may need to apply licenses to other repos as well. 

@mikeal I'm not at all positive I've correctly interpreted your suggestion in #130. 

I don't know how "There's no CLA or copyright assignment as part of the contribution process." fits into what we add to our page, or how it fits with the fact that both of the proposed licenses include a place for a copyright assignment.

 I've filled in the copyright assignment in the licenses as Protocol Labs. Is this correct, and is it right that it's 2019 (should it be 2018-2019 based on when work started)? 

I"ll get your feedback on this PR first before trying to apply a license to other repos. Do we need one on the organizing repo and the individual chapter repos as well? 