### PR TITLE
Use 2-digit country codes

### DIFF
--- a/src/components/chapters/chapters.json
+++ b/src/components/chapters/chapters.json
@@ -2,7 +2,7 @@
    {
       "name":"ProtoSchool San Francisco",
       "city":"San Francisco, CA",
-      "country":"USA",
+      "country":"US",
       "region":"North America",
       "organizers":[
          "mikeal"
@@ -12,7 +12,7 @@
    {
      "name":"ProtoSchool Denver",
      "city":"Denver, CO",
-     "country":"USA",
+     "country":"US",
      "region":"North America",
      "organizers":[
         "NukeManDan"


### PR DESCRIPTION
- Use 2-digit country codes for consistency as specified in chapter
setup instructions