### PR TITLE
fix: ensure ipfs browser bundle is used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1375,19 +1375,6 @@
       "integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
       "dev": true
     },
-    "File": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/File/-/File-0.10.2.tgz",
-      "integrity": "sha1-6Jn3dtJz4iQ7qGEFuzsFbQ+5VgQ=",
-      "requires": {
-        "mime": ">= 0.0.0"
-      }
-    },
-    "FileList": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/FileList/-/FileList-0.10.2.tgz",
-      "integrity": "sha1-YAOxqXFZNBZLZ8Q0rWqHQaHNFHo="
-    },
     "abstract-leveldown": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
@@ -1603,7 +1590,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -1708,6 +1695,11 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asmcrypto.js": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-2.3.2.tgz",
+      "integrity": "sha512-3FgFARf7RupsZETQ1nHnhLUUvpcttcCq1iZCaVAbJZbCZ5VNRrNyvpDyHTOb0KC3llFcsyOT/a99NZcCbeiEsA=="
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -1731,7 +1723,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "dev": true,
       "requires": {
         "util": "0.10.3"
       },
@@ -1739,14 +1730,12 @@
         "inherits": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "util": {
           "version": "0.10.3",
           "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-          "dev": true,
           "requires": {
             "inherits": "2.0.1"
           }
@@ -1784,6 +1773,15 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
+    },
+    "async-iterator-to-pull-stream": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/async-iterator-to-pull-stream/-/async-iterator-to-pull-stream-1.2.1.tgz",
+      "integrity": "sha512-STQB0sczzBjC1ttIQop4XdZLeFrGM6L4eq7LOit+CG+iwwIfGjIKzuAzZFzLqulZHp+Qu5fLk8V7kwLLYnNUlA==",
+      "requires": {
+        "get-iterator": "^1.0.1",
+        "pull-stream-to-async-iterator": "^1.0.1"
+      }
     },
     "async-limiter": {
       "version": "1.0.0",
@@ -2171,9 +2169,9 @@
       }
     },
     "base32-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.1.0.tgz",
-      "integrity": "sha512-fQWhpkWtaOPr+wvXWYDu1AfRbtIIzWDt3yDDNXLENWPwFyyxDJfVaJoOc1ks1TQckogPiHmb+0iZLQFPkZw8kg=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.1.1.tgz",
+      "integrity": "sha512-eqa0BeGghj3guezlasdHJhr3+J5ZbbQvxeprkcDMbRQrjlqOT832IUDT4Al4ofAwekFYMqkkM9KMUHs9Cu0HKA=="
     },
     "base32.js": {
       "version": "0.1.0",
@@ -2244,15 +2242,10 @@
         "tryer": "^1.0.0"
       }
     },
-    "big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
-    },
     "bignumber.js": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
     },
     "binary-extensions": {
       "version": "1.12.0",
@@ -2266,9 +2259,12 @@
       "integrity": "sha512-mrot/6OS3YIUSWMyv/9uyMbCDYQWxl+fVDsrJFjPFGcVT0xDCdEg/gbN6eguaCr0UqsuXdtJ3DQ3i2z2alnulg=="
     },
     "bindings": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
-      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bintrees": {
       "version": "1.0.1",
@@ -2302,9 +2298,9 @@
       "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
     },
     "bitcoinjs-lib": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-4.0.2.tgz",
-      "integrity": "sha512-Y6AW91WPDoDQQLy4FejVoH4NvENqvMy+Q/8mnakEzckG1NXiLo0VgnEZyuvZb6lkhE2+YxzTCgpqzbnerOSpEg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-4.0.3.tgz",
+      "integrity": "sha512-cb5t55MYUpwQi095J+u6eyltgIU7lbhZfC6+annstncDhfH4cyctW5jmU/tac7NonZZFYH7DktWnDxUm9AWWDQ==",
       "requires": {
         "bech32": "^1.1.2",
         "bip32": "^1.0.0",
@@ -2324,9 +2320,9 @@
       }
     },
     "bl": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.1.2.tgz",
-      "integrity": "sha512-DvC0x+PxmSJNx8wXoFV15pC2+GOJ3ohb4F1REq3X32a2Z3nEBpR1Guu740M7ouYAImFj4BXDNilLNZbygtG9lQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
+      "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -2334,7 +2330,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2483,15 +2479,21 @@
       }
     },
     "borc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.0.4.tgz",
-      "integrity": "sha512-SCVjto/dbKfduyl+LDQ1Km28ly2aTIXtJbrYZWHFQAxkHph96I/zXTrTQXWuJobG8lQZjIA/dw9z7hmJHJhjMg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.0.tgz",
+      "integrity": "sha512-hKTxeYt3AIzIG45epJHv8xJYSF0ktp7nZgFsqi5cPzoL3T8qKMPeUlqydORy6j3NWZvRDANx30PjpTmGho69Gw==",
       "requires": {
-        "bignumber.js": "^7.2.1",
+        "bignumber.js": "^8.0.1",
         "commander": "^2.15.0",
         "ieee754": "^1.1.8",
-        "json-text-sequence": "^0.1"
+        "iso-url": "~0.4.4",
+        "json-text-sequence": "~0.1.0"
       }
+    },
+    "bourne": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bourne/-/bourne-1.1.2.tgz",
+      "integrity": "sha512-b2dgVkTZhkQirNMohgC00rWfpVqEi9y5tKM1k3JvoNx05ODtfQoPPd4js9CYFQoY0IM8LAmnJulEuWv74zjUOg=="
     },
     "boxen": {
       "version": "1.3.0",
@@ -2709,11 +2711,6 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
-    "bufferjs": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bufferjs/-/bufferjs-3.0.1.tgz",
-      "integrity": "sha1-BpLoKcsQoQVQ5kc5CwNesGw46O8="
-    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -2883,9 +2880,9 @@
       }
     },
     "camelcase": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+      "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ=="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -2973,6 +2970,11 @@
         }
       }
     },
+    "chai-checkmark": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chai-checkmark/-/chai-checkmark-1.0.1.tgz",
+      "integrity": "sha1-n7s8mtkQHwl+8ogyjTD0In10//s="
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -3041,25 +3043,15 @@
       "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
     },
     "cid-tool": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cid-tool/-/cid-tool-0.1.0.tgz",
-      "integrity": "sha512-lss0IzW2uiLm+W8St00N23+ySnCoFTD7qPZB1WqqOSvT5mzDG8Di9e5LmcaEkNfFXh7xAmlPZmJnvWxAjVPErg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/cid-tool/-/cid-tool-0.2.0.tgz",
+      "integrity": "sha512-YQcNOpK+hgfkedrqkQCa7vpXLMRooP1OwJmzhEc6m6ggzva+4yPaPNjMqmY7OPizGvf1kkoKHs/ZWWJOH8eylg==",
       "requires": {
-        "cids": "~0.5.3",
+        "cids": "~0.5.6",
         "explain-error": "^1.0.4",
-        "multibase": "~0.5.0",
+        "multibase": "~0.6.0",
         "multihashes": "~0.4.14",
         "yargs": "^12.0.2"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.5.0.tgz",
-          "integrity": "sha512-7epKiK8/UBzraYZvOuZa8FH/00hMfTnzTy1OQol1YBU2csAYA7rwWh+iue9plXRmVFBGvmVKMuo0oq5sD47kvw==",
-          "requires": {
-            "base-x": "3.0.4"
-          }
-        }
       }
     },
     "cids": {
@@ -3577,11 +3569,6 @@
         }
       }
     },
-    "core-decorators": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.20.0.tgz",
-      "integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU="
-    },
     "core-js": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
@@ -3996,18 +3983,18 @@
       }
     },
     "datastore-fs": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.7.0.tgz",
-      "integrity": "sha512-U8amTi/aWW391JYeFbIzjKtEqECXuMvDafD0XphsiaRKp0If4SwxgmlMn+y7BHlCRrf4/AYAwemVZBMBrSwIxA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.8.0.tgz",
+      "integrity": "sha512-uaNVJtMQKNxxJkqKGrI5dYhciUIZSntHVCS3pU4qimke8tSp9pCkXwgLoxORxX1z411sF1Im5cc9RlnJT7NOMg==",
       "requires": {
         "async": "^2.6.1",
         "datastore-core": "~0.6.0",
+        "fast-write-atomic": "~0.2.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.1.11",
         "interface-datastore": "~0.6.0",
         "mkdirp": "~0.5.1",
-        "pull-stream": "^3.6.9",
-        "write-file-atomic": "^2.3.0"
+        "pull-stream": "^3.6.9"
       }
     },
     "datastore-level": {
@@ -4022,6 +4009,18 @@
         "leveldown": "^3.0.2",
         "levelup": "^2.0.2",
         "pull-stream": "^3.6.9"
+      }
+    },
+    "datastore-pubsub": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/datastore-pubsub/-/datastore-pubsub-0.1.1.tgz",
+      "integrity": "sha512-yxAMVI51ZxuGaiEUQW0w3picNHHrUDvOIlgCdnMsa4pYgWi1R4jJAAV1tkYHTPUOXyp9UUIVnNyoeJ/CSLjlzA==",
+      "requires": {
+        "assert": "^1.4.1",
+        "debug": "^4.1.0",
+        "err-code": "^1.1.2",
+        "interface-datastore": "~0.6.0",
+        "multibase": "~0.6.0"
       }
     },
     "date-now": {
@@ -4103,16 +4102,6 @@
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
-      }
-    },
-    "defaults-deep": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/defaults-deep/-/defaults-deep-0.2.4.tgz",
-      "integrity": "sha512-V6BtqzcMvn0EPOy7f+SfMhfmTawq+7UQdt9yZH0EBK89+IHo5f+Hse/qzTorAXOBrQpxpwb6cB/8OgtaMrT+Fg==",
-      "requires": {
-        "for-own": "^0.1.3",
-        "is-extendable": "^0.1.1",
-        "lazy-cache": "^0.2.3"
       }
     },
     "deferred-leveldown": {
@@ -4605,9 +4594,9 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "ws": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
-          "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
           "requires": {
             "async-limiter": "~1.0.0"
           }
@@ -4615,9 +4604,9 @@
       }
     },
     "engine.io-client": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.1.tgz",
-      "integrity": "sha512-q66JBFuQcy7CSlfAz9L3jH+v7DTT3i6ZEadYcVj2pOs8/0uJHLxKX3WBkGTvULJMdz0tUCyJag0aKT/dpXL9BQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.2.tgz",
+      "integrity": "sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==",
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
@@ -4646,9 +4635,9 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "ws": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
-          "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
           "requires": {
             "async-limiter": "~1.0.0"
           }
@@ -5373,21 +5362,156 @@
       }
     },
     "ethereumjs-block": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.1.0.tgz",
-      "integrity": "sha512-ip+x4/7hUInX+TQfhEKsQh9MJK1Dbjp4AuPjf1UdX3udAV4beYD4EMCNIPzBLCsGS8WQZYXLpo83tVTISYNpow==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.0.tgz",
+      "integrity": "sha512-Ye+uG/L2wrp364Zihdlr/GfC3ft+zG8PdHcRtsBFNNH1CkOhxOwdB8friBU85n89uRZ9eIMAywCq0F4CwT1wAw==",
       "requires": {
         "async": "^2.0.1",
-        "ethereumjs-common": "^0.6.0",
+        "ethereumjs-common": "^1.1.0",
         "ethereumjs-tx": "^1.2.2",
         "ethereumjs-util": "^5.0.0",
         "merkle-patricia-tree": "^2.1.2"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
+        "deferred-leveldown": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+          "requires": {
+            "abstract-leveldown": "~2.6.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "level-codec": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
+        },
+        "level-errors": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+          "requires": {
+            "errno": "~0.1.1"
+          }
+        },
+        "level-iterator-stream": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+          "requires": {
+            "inherits": "^2.0.1",
+            "level-errors": "^1.0.3",
+            "readable-stream": "^1.0.33",
+            "xtend": "^4.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.14",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            }
+          }
+        },
+        "levelup": {
+          "version": "1.3.9",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+          "requires": {
+            "deferred-leveldown": "~1.2.1",
+            "level-codec": "~7.0.0",
+            "level-errors": "~1.0.3",
+            "level-iterator-stream": "~1.3.0",
+            "prr": "~1.0.1",
+            "semver": "~5.4.1",
+            "xtend": "~4.0.0"
+          }
+        },
+        "merkle-patricia-tree": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+          "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
+          "requires": {
+            "async": "^1.4.2",
+            "ethereumjs-util": "^5.0.0",
+            "level-ws": "0.0.0",
+            "levelup": "^1.2.1",
+            "memdown": "^1.0.0",
+            "readable-stream": "^2.0.0",
+            "rlp": "^2.0.0",
+            "semaphore": ">=1.0.1"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
       }
     },
     "ethereumjs-common": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-0.6.1.tgz",
-      "integrity": "sha512-4jOrfDu9qOBTTGGb3zrfT1tE1Hyc6a8LJpEk0Vk9AYlLkBY7crjVICyJpRvjNI+KLDMpMITMw3eWVZOLMtZdhw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.1.0.tgz",
+      "integrity": "sha512-LUmYkKV/HcZbWRyu3OU9YOevsH3VJDXtI6kEd8VZweQec+JjDGKCmAVKUyzhYUHqxRJu7JNALZ3A/b3NXOP6tA=="
     },
     "ethereumjs-tx": {
       "version": "1.3.7",
@@ -5738,6 +5862,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-write-atomic": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-write-atomic/-/fast-write-atomic-0.2.0.tgz",
+      "integrity": "sha512-0aavsEg6PMSkVedGj+W03z/fSlU2JQbhSqU6SZBFXsLdyQ+sxwIF/MvlDJk6t60USWrpsGPu7ooURWoKQYRlrQ=="
+    },
     "fastparse": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
@@ -5768,21 +5897,6 @@
         "escape-string-regexp": "^1.0.5"
       }
     },
-    "file-api": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/file-api/-/file-api-0.10.4.tgz",
-      "integrity": "sha1-LxASJttyfMAXKg3WiPL2iD1SiD0=",
-      "requires": {
-        "File": ">= 0.10.0",
-        "FileList": ">= 0.10.0",
-        "bufferjs": "> 0.2.0",
-        "file-error": ">= 0.10.0",
-        "filereader": ">= 0.10.3",
-        "formdata": ">= 0.10.0",
-        "mime": ">= 1.2.11",
-        "remedial": ">= 1.0.7"
-      }
-    },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
@@ -5800,11 +5914,6 @@
           "dev": true
         }
       }
-    },
-    "file-error": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/file-error/-/file-error-0.10.2.tgz",
-      "integrity": "sha1-ljtIuSc7PUuEtADuVxvHixc5cko="
     },
     "file-loader": {
       "version": "2.0.0",
@@ -5836,14 +5945,14 @@
       }
     },
     "file-type": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.6.0.tgz",
-      "integrity": "sha512-GNOg09GC+rZzxetGZFoL7QOnWXRqvWuEdKURIJlr0d6MW107Iwy6voG1PPOrm5meG6ls59WkBmBMAZdVSVajRQ=="
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.9.0.tgz",
+      "integrity": "sha512-9C5qtGR/fNibHC5gzuMmmgnjH3QDDLKMa8lYe9CiZVmAnI4aUaoMh40QyUPzzs0RYo837SOBKh7TYwle4G8E4w=="
     },
-    "filereader": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/filereader/-/filereader-0.10.3.tgz",
-      "integrity": "sha1-x0fUos2PYeVBinwH/hJXpD8KzbE="
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filereader-stream": {
       "version": "2.0.0",
@@ -6022,20 +6131,8 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "requires": {
-        "for-in": "^1.0.1"
-      }
-    },
-    "foreachasync": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
-      "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -6052,26 +6149,6 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
-      }
-    },
-    "formdata": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/formdata/-/formdata-0.10.4.tgz",
-      "integrity": "sha1-liH9wMw2H0oBEd5dJbNfanjcVaA=",
-      "requires": {
-        "File": "^0.10.2",
-        "FileList": "^0.10.2",
-        "bufferjs": "^2.0.0",
-        "filereader": "^0.10.3",
-        "foreachasync": "^3.0.0",
-        "remedial": "^1.0.7"
-      },
-      "dependencies": {
-        "bufferjs": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/bufferjs/-/bufferjs-2.0.0.tgz",
-          "integrity": "sha1-aF5x7VwGAOPXA/+b0BK7MnCjnig="
-        }
       }
     },
     "forwarded": {
@@ -6780,9 +6857,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gar": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.3.tgz",
-      "integrity": "sha512-zDpwk/l3HbhjVAvdxNUTJFzgXiNy0a7EmE/50XT38o1z+7NJbFhp+8CDsv1Qgy2adBAwUVYlMpIX2fZUbmlUJw=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.4.tgz",
+      "integrity": "sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w=="
     },
     "gauge": {
       "version": "2.7.4",
@@ -6829,7 +6906,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -7312,13 +7389,18 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
     "get-folder-size": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-2.0.0.tgz",
-      "integrity": "sha512-5h4efQY/sHvf9ZuwOan1HgNaRyApKnJjZ1ZdTOPkpTjIHZNqeMTabBU/LLN6lU9jncBwxJKFcG9cuqiGhu47uQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-2.0.1.tgz",
+      "integrity": "sha512-+CEb+GDCM7tkOS2wdMKTn9vU7DgnKUTuDlehkNJKNSovdCOVxs14OfKCk4cvSaR3za4gj+OBdl9opPN9xrJ0zA==",
       "requires": {
-        "gar": "^1.0.2",
+        "gar": "^1.0.4",
         "tiny-each-async": "2.0.3"
       }
+    },
+    "get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
     },
     "get-stream": {
       "version": "3.0.0",
@@ -7445,6 +7527,14 @@
       "requires": {
         "duplexer": "^0.1.1",
         "pify": "^3.0.0"
+      }
+    },
+    "hamt-sharding": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-0.0.2.tgz",
+      "integrity": "sha512-0pUBRvsdM1G6RgXfJASUMLwk++LQMNoXx2n2iMZiSzV43lBNesSz130wkGSP2D6d/8DYIWABLL1Vqb4PpcUcvQ==",
+      "requires": {
+        "sparse-array": "^1.3.1"
       }
     },
     "handle-thing": {
@@ -7727,7 +7817,8 @@
     "hoek": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
-      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
+      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
+      "dev": true
     },
     "hoopy": {
       "version": "0.1.4",
@@ -8297,8 +8388,7 @@
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
-      "dev": true
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
     "ipaddr.js": {
       "version": "1.8.0",
@@ -8307,20 +8397,23 @@
       "dev": true
     },
     "ipfs": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.33.1.tgz",
-      "integrity": "sha512-He22aMi/qJYcao4zkh9fS1cZZWKPWIyO964j/Bt+DhEUVO79DBBGW+PuF3I8IfVE8ihDxImxNboal3pbZT9EdA==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.34.4.tgz",
+      "integrity": "sha512-BhNVdWRE9lP+D/DfAI4L3rtIFg3trxpkEbCELBA7+mLi5ZkVnNpsOvvlcn3eJdufwqBj0/9x2xbOP1YQzZfEKg==",
       "requires": {
         "@nodeutils/defaults-deep": "^1.1.0",
         "async": "^2.6.1",
-        "big.js": "^5.2.2",
+        "bignumber.js": "^8.0.2",
         "binary-querystring": "~0.1.2",
         "bl": "^2.1.2",
         "boom": "^7.2.0",
         "bs58": "^4.0.1",
         "byteman": "^1.3.5",
-        "cid-tool": "~0.1.0",
+        "cid-tool": "~0.2.0",
         "cids": "~0.5.5",
+        "class-is": "^1.1.0",
+        "datastore-core": "~0.6.0",
+        "datastore-pubsub": "~0.1.1",
         "debug": "^4.1.0",
         "err-code": "^1.1.2",
         "file-type": "^10.2.0",
@@ -8330,178 +8423,146 @@
         "glob": "^7.1.3",
         "hapi": "^16.6.2",
         "hapi-set-header": "^1.0.2",
-        "hoek": "^5.0.4",
+        "hoek": "^6.1.2",
         "human-to-milliseconds": "^1.0.0",
         "interface-datastore": "~0.6.0",
-        "ipfs-api": "^26.1.0",
-        "ipfs-bitswap": "~0.21.0",
+        "ipfs-bitswap": "~0.22.0",
         "ipfs-block": "~0.8.0",
         "ipfs-block-service": "~0.15.1",
-        "ipfs-http-response": "~0.2.0",
-        "ipfs-mfs": "~0.4.2",
+        "ipfs-http-client": "^29.0.0",
+        "ipfs-http-response": "~0.2.1",
+        "ipfs-mfs": "~0.8.0",
         "ipfs-multipart": "~0.1.0",
-        "ipfs-repo": "~0.25.0",
+        "ipfs-repo": "~0.26.1",
         "ipfs-unixfs": "~0.1.16",
-        "ipfs-unixfs-engine": "~0.33.0",
-        "ipld": "~0.19.1",
+        "ipfs-unixfs-engine": "~0.35.3",
+        "ipld": "~0.20.1",
         "ipld-bitcoin": "~0.1.8",
-        "ipld-dag-pb": "~0.14.11",
+        "ipld-dag-pb": "~0.15.0",
         "ipld-ethereum": "^2.0.1",
         "ipld-git": "~0.2.2",
-        "ipld-raw": "^2.0.1",
         "ipld-zcash": "~0.1.6",
-        "ipns": "~0.3.0",
-        "is-ipfs": "~0.4.7",
+        "ipns": "~0.5.0",
+        "is-ipfs": "~0.4.8",
         "is-pull-stream": "~0.0.0",
         "is-stream": "^1.1.0",
-        "joi": "^13.4.0",
+        "joi": "^14.3.0",
         "joi-browser": "^13.4.0",
-        "joi-multiaddr": "^2.0.0",
-        "libp2p": "~0.23.1",
+        "joi-multiaddr": "^4.0.0",
+        "libp2p": "~0.24.1",
         "libp2p-bootstrap": "~0.9.3",
-        "libp2p-crypto": "~0.14.0",
-        "libp2p-kad-dht": "~0.10.6",
+        "libp2p-crypto": "~0.16.0",
+        "libp2p-kad-dht": "~0.14.4",
         "libp2p-keychain": "~0.3.3",
         "libp2p-mdns": "~0.12.0",
-        "libp2p-mplex": "~0.8.2",
-        "libp2p-record": "~0.6.0",
-        "libp2p-secio": "~0.10.0",
+        "libp2p-mplex": "~0.8.4",
+        "libp2p-record": "~0.6.1",
+        "libp2p-secio": "~0.11.0",
         "libp2p-tcp": "~0.13.0",
         "libp2p-webrtc-star": "~0.15.5",
-        "libp2p-websocket-star": "~0.9.0",
+        "libp2p-websocket-star-multi": "~0.4.0",
         "libp2p-websockets": "~0.12.0",
         "lodash": "^4.17.11",
         "mafmt": "^6.0.2",
         "mime-types": "^2.1.21",
         "mkdirp": "~0.5.1",
-        "multiaddr": "^5.0.0",
+        "multiaddr": "^6.0.0",
         "multiaddr-to-uri": "^4.0.0",
-        "multibase": "~0.5.0",
+        "multibase": "~0.6.0",
         "multihashes": "~0.4.14",
+        "multihashing-async": "~0.5.1",
+        "node-fetch": "^2.3.0",
         "once": "^1.4.0",
-        "peer-book": "~0.8.0",
+        "peer-book": "~0.9.0",
         "peer-id": "~0.12.0",
-        "peer-info": "~0.14.1",
+        "peer-info": "~0.15.0",
         "progress": "^2.0.1",
         "prom-client": "^11.1.3",
         "prometheus-gc-stats": "~0.6.0",
         "promisify-es6": "^1.0.3",
+        "protons": "^1.0.1",
         "pull-abortable": "^4.1.1",
-        "pull-catch": "^1.0.0",
+        "pull-cat": "^1.1.11",
         "pull-defer": "~0.2.3",
         "pull-file": "^1.1.0",
         "pull-ndjson": "~0.1.1",
-        "pull-paramap": "^1.2.2",
         "pull-pushable": "^2.2.0",
         "pull-sort": "^1.0.1",
         "pull-stream": "^3.6.9",
         "pull-stream-to-stream": "^1.3.4",
-        "pull-zip": "^2.0.1",
         "pump": "^3.0.0",
         "read-pkg-up": "^4.0.0",
-        "readable-stream": "3.0.6",
+        "readable-stream": "^3.1.1",
         "receptacle": "^1.3.2",
         "stream-to-pull-stream": "^1.7.2",
         "tar-stream": "^1.6.2",
-        "temp": "~0.8.3",
+        "temp": "~0.9.0",
         "update-notifier": "^2.5.0",
-        "yargs": "^12.0.2",
+        "varint": "^5.0.0",
+        "yargs": "^12.0.5",
         "yargs-promise": "^1.1.0"
       },
       "dependencies": {
-        "multibase": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.5.0.tgz",
-          "integrity": "sha512-7epKiK8/UBzraYZvOuZa8FH/00hMfTnzTy1OQol1YBU2csAYA7rwWh+iue9plXRmVFBGvmVKMuo0oq5sD47kvw==",
+        "hoek": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+          "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
+        },
+        "isemail": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+          "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
           "requires": {
-            "base-x": "3.0.4"
+            "punycode": "2.x.x"
           }
-        }
-      }
-    },
-    "ipfs-api": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-26.1.2.tgz",
-      "integrity": "sha512-HkM6vQOHL9z9ZCXIrbDXvAOsIzfWPaAac9kY+SjUuVqMydWHzP8qTxfv5jaXResGbmLcbwcROhuqgJU+HrclSg==",
-      "requires": {
-        "async": "^2.6.1",
-        "big.js": "^5.2.2",
-        "bl": "^2.1.2",
-        "bs58": "^4.0.1",
-        "cids": "~0.5.5",
-        "concat-stream": "^1.6.2",
-        "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "end-of-stream": "^1.4.1",
-        "flatmap": "0.0.3",
-        "glob": "^7.1.3",
-        "ipfs-block": "~0.8.0",
-        "ipfs-unixfs": "~0.1.16",
-        "ipld-dag-cbor": "~0.13.0",
-        "ipld-dag-pb": "~0.14.11",
-        "is-ipfs": "~0.4.7",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^1.1.0",
-        "libp2p-crypto": "~0.14.0",
-        "lodash": "^4.17.11",
-        "lru-cache": "^4.1.3",
-        "multiaddr": "^5.0.0",
-        "multibase": "~0.5.0",
-        "multihashes": "~0.4.14",
-        "ndjson": "^1.5.0",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.0",
-        "peer-info": "~0.14.1",
-        "promisify-es6": "^1.0.3",
-        "pull-defer": "~0.2.3",
-        "pull-pushable": "^2.2.0",
-        "pull-stream-to-stream": "^1.3.4",
-        "pump": "^3.0.0",
-        "qs": "^6.5.2",
-        "readable-stream": "^3.0.6",
-        "stream-http": "^3.0.0",
-        "stream-to-pull-stream": "^1.7.2",
-        "streamifier": "~0.1.1",
-        "tar-stream": "^1.6.2",
-        "through2": "^2.0.3"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.5.0.tgz",
-          "integrity": "sha512-7epKiK8/UBzraYZvOuZa8FH/00hMfTnzTy1OQol1YBU2csAYA7rwWh+iue9plXRmVFBGvmVKMuo0oq5sD47kvw==",
+        },
+        "joi": {
+          "version": "14.3.1",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
+          "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
           "requires": {
-            "base-x": "3.0.4"
+            "hoek": "6.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
+          }
+        },
+        "readable-stream": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
+          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "topo": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+          "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+          "requires": {
+            "hoek": "6.x.x"
           }
         }
       }
     },
     "ipfs-bitswap": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.21.0.tgz",
-      "integrity": "sha512-gsKGv3pa98jVQZURZcubW/LPpj0SX2UjISosF+7Nnmp4oR1RtTNBIhY+OyvlNGMWo8BqfVZb/iB0Z1+FME6CAw==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.22.0.tgz",
+      "integrity": "sha512-hgLwX1PUTMgVFbjWjSdasZLhj6ODEuJ/65xwkQGXSDZCrLIyKILp9kH2ZMspSBeSWzeQF4B5QDpB5FxKg6J2PA==",
       "requires": {
         "async": "^2.6.1",
-        "big.js": "^5.2.2",
+        "bignumber.js": "^8.0.1",
         "cids": "~0.5.5",
         "debug": "^4.1.0",
         "ipfs-block": "~0.8.0",
-        "lodash.debounce": "^4.0.8",
-        "lodash.find": "^4.6.0",
-        "lodash.groupby": "^4.6.0",
+        "just-debounce-it": "^1.1.0",
         "lodash.isequalwith": "^4.4.0",
-        "lodash.isundefined": "^3.0.1",
-        "lodash.pullallwith": "^4.7.0",
-        "lodash.sortby": "^4.7.0",
-        "lodash.uniqwith": "^4.5.0",
-        "lodash.values": "^4.3.0",
         "moving-average": "^1.0.0",
         "multicodec": "~0.2.7",
         "multihashing-async": "~0.5.1",
         "protons": "^1.0.1",
-        "pull-defer": "~0.2.3",
         "pull-length-prefixed": "^1.3.1",
-        "pull-pushable": "^2.2.0",
         "pull-stream": "^3.6.9",
         "varint-decoder": "~0.1.1"
       }
@@ -8528,28 +8589,121 @@
       "resolved": "https://registry.npmjs.org/ipfs-css/-/ipfs-css-0.6.0.tgz",
       "integrity": "sha512-3VEXi2XIT31FxKCyT0Qy68JiP1kVqeAOkXQz6mpggVpFgoUiiZt5YJy9jEb+RswTTh7sfszfk1iE8RJMAmfItw=="
     },
-    "ipfs-http-response": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.2.1.tgz",
-      "integrity": "sha512-A3FPRa/IqiGE0dNRDDYRdDnPsq5eBuJWpASWGuEzTeGAh7Ad5dvIaU9JyIcLlcLLF3tAhueUnaFxjgAhot7xog==",
+    "ipfs-http-client": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-29.1.1.tgz",
+      "integrity": "sha512-aAjqZ9RwnpQECkMO058YjWG79U4w4wEKvHfVdXMhgkXDFkErxRpSqoCvwIVozbTU34NwEjWsZ9WoG0lr2FtgvA==",
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
+        "bignumber.js": "^8.0.2",
+        "bl": "^2.1.2",
+        "bs58": "^4.0.1",
         "cids": "~0.5.5",
-        "debug": "^3.1.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "end-of-stream": "^1.4.1",
+        "err-code": "^1.1.2",
+        "flatmap": "0.0.3",
+        "glob": "^7.1.3",
+        "ipfs-block": "~0.8.0",
+        "ipfs-unixfs": "~0.1.16",
+        "ipld-dag-cbor": "~0.13.0",
+        "ipld-dag-pb": "~0.15.0",
+        "is-ipfs": "~0.4.7",
+        "is-pull-stream": "0.0.0",
+        "is-stream": "^1.1.0",
+        "libp2p-crypto": "~0.16.0",
+        "lodash": "^4.17.11",
+        "lru-cache": "^5.1.1",
+        "multiaddr": "^6.0.0",
+        "multibase": "~0.6.0",
+        "multihashes": "~0.4.14",
+        "ndjson": "^1.5.0",
+        "once": "^1.4.0",
+        "peer-id": "~0.12.1",
+        "peer-info": "~0.15.0",
+        "promisify-es6": "^1.0.3",
+        "pull-defer": "~0.2.3",
+        "pull-pushable": "^2.2.0",
+        "pull-stream-to-stream": "^1.3.4",
+        "pump": "^3.0.0",
+        "qs": "^6.5.2",
+        "readable-stream": "^3.0.6",
+        "stream-http": "^3.0.0",
+        "stream-to-pull-stream": "^1.7.2",
+        "streamifier": "~0.1.1",
+        "tar-stream": "^1.6.2",
+        "through2": "^3.0.0"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
+      }
+    },
+    "ipfs-http-response": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.2.2.tgz",
+      "integrity": "sha512-RMc9GUdyfFdOclobCXslfS+tGevJJs9ZhUv1xuJd32d1CVEd3PlZB2VBgWPMP5jXyZJWQ9kkAha8fBHGtC55Cw==",
+      "requires": {
+        "async": "^2.6.1",
+        "cids": "~0.5.7",
+        "debug": "^4.1.1",
         "file-type": "^8.0.0",
         "filesize": "^3.6.1",
         "get-stream": "^3.0.0",
-        "ipfs-unixfs": "~0.1.14",
-        "mime-types": "^2.1.18",
-        "multihashes": "~0.4.13",
+        "ipfs-unixfs": "~0.1.16",
+        "mime-types": "^2.1.21",
+        "multihashes": "~0.4.14",
         "promisify-es6": "^1.0.3",
         "stream-to-blob": "^1.0.1"
       },
       "dependencies": {
+        "cids": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.7.tgz",
+          "integrity": "sha512-SlAz4p8XMEW3mhwiYbzfjn+5+Y//+kIuHqzRUytK0a3uGBnsjJb76xHliehv0HcVMCjRKv2vZnPTwd4QX+IcMA==",
+          "requires": {
+            "class-is": "^1.1.0",
+            "multibase": "~0.6.0",
+            "multicodec": "~0.2.7",
+            "multihashes": "~0.4.14"
+          }
+        },
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -8562,62 +8716,64 @@
       }
     },
     "ipfs-mfs": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.4.2.tgz",
-      "integrity": "sha512-6xcexwgnyXXbi3PeXfmCtKa8nMijm8lvRPvfm27/Jwv/gLU1sJkpI6KF0m/EBeM7mwl1pQYu4E03qVoz8hDxtA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.8.2.tgz",
+      "integrity": "sha512-+HxjWSI9L6v/qXTEZgoPydMYBHYydjfmqnWzGprrWp3I60Yt+eGoao4+6aiPOepinWMF2Peh7wkaefTVUJFXpA==",
       "requires": {
         "async": "^2.6.1",
-        "blob": "~0.0.4",
-        "cids": "~0.5.4",
-        "debug": "^4.0.1",
-        "file-api": "~0.10.4",
+        "cids": "~0.5.5",
+        "debug": "^4.1.0",
         "filereader-stream": "^2.0.0",
+        "hamt-sharding": "~0.0.2",
         "interface-datastore": "~0.6.0",
-        "ipfs-unixfs": "~0.1.15",
-        "ipfs-unixfs-engine": "~0.32.1",
+        "ipfs-multipart": "~0.1.0",
+        "ipfs-unixfs": "~0.1.16",
+        "ipfs-unixfs-exporter": "~0.35.5",
+        "ipfs-unixfs-importer": "~0.38.0",
+        "ipld-dag-pb": "~0.15.0",
         "is-pull-stream": "~0.0.0",
         "is-stream": "^1.1.0",
-        "joi": "^13.4.0",
+        "joi": "^14.0.4",
         "joi-browser": "^13.4.0",
-        "mortice": "^1.2.0",
+        "mortice": "^1.2.1",
         "once": "^1.4.0",
         "promisify-es6": "^1.0.3",
         "pull-cat": "^1.1.11",
-        "pull-defer": "~0.2.2",
-        "pull-paramap": "^1.2.2",
-        "pull-pushable": "^2.2.0",
+        "pull-defer": "~0.2.3",
         "pull-stream": "^3.6.9",
         "pull-stream-to-stream": "^1.3.4",
-        "pull-traverse": "^1.0.3",
         "stream-to-pull-stream": "^1.7.2"
       },
       "dependencies": {
-        "ipfs-unixfs-engine": {
-          "version": "0.32.8",
-          "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.32.8.tgz",
-          "integrity": "sha512-YqLppNmG5M0rFj7QOTdRjny8xNKxmqKJE5DCOtc2ZMaXd4Semq+rEH23N2Mr1jYpimboDnadcv6jszi5cWRexw==",
+        "hoek": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+          "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
+        },
+        "isemail": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+          "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
           "requires": {
-            "async": "^2.6.1",
-            "cids": "~0.5.5",
-            "deep-extend": "~0.6.0",
-            "ipfs-unixfs": "~0.1.15",
-            "ipld-dag-pb": "~0.14.6",
-            "left-pad": "^1.3.0",
-            "multihashing-async": "~0.5.1",
-            "pull-batch": "^1.0.0",
-            "pull-block": "^1.4.0",
-            "pull-cat": "^1.1.11",
-            "pull-pair": "^1.1.0",
-            "pull-paramap": "^1.2.2",
-            "pull-pause": "0.0.2",
-            "pull-pushable": "^2.2.0",
-            "pull-stream": "^3.6.9",
-            "pull-through": "^1.0.18",
-            "pull-traverse": "^1.0.3",
-            "pull-write": "^1.1.4",
-            "rabin": "^1.6.0",
-            "sparse-array": "^1.3.1",
-            "stream-to-pull-stream": "^1.7.2"
+            "punycode": "2.x.x"
+          }
+        },
+        "joi": {
+          "version": "14.3.1",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
+          "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
+          "requires": {
+            "hoek": "6.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
+          }
+        },
+        "topo": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+          "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+          "requires": {
+            "hoek": "6.x.x"
           }
         }
       }
@@ -8632,36 +8788,54 @@
       }
     },
     "ipfs-repo": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.25.2.tgz",
-      "integrity": "sha512-TuhUdturwwG/hKdK2m1fv6Hz1hvHsdXQqAsDr0uEXK8WOfz7CZ9IHLU3feDTDhh8nr4fB0nOO5xaTz3cCZ+/9Q==",
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.26.2.tgz",
+      "integrity": "sha512-IK795lRQrblFiO5rITK8LzCnKM1Iq/xIBsnTqVCk3eE3u88rNGZ6ZvZCa+xnm5oz7/yheUhWV9xG7W93HPhrYw==",
       "requires": {
-        "async": "^2.6.1",
+        "async": "^2.6.2",
         "base32.js": "~0.1.0",
-        "big.js": "^5.2.2",
-        "cids": "~0.5.5",
+        "bignumber.js": "^8.0.2",
+        "cids": "~0.5.7",
         "datastore-core": "~0.6.0",
-        "datastore-fs": "~0.7.0",
+        "datastore-fs": "~0.8.0",
         "datastore-level": "~0.10.0",
-        "debug": "^4.1.0",
+        "debug": "^4.1.1",
         "interface-datastore": "~0.6.0",
-        "ipfs-block": "~0.7.1",
+        "ipfs-block": "~0.8.0",
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
         "lodash.set": "^4.3.2",
-        "multiaddr": "^5.0.0",
+        "multiaddr": "^6.0.4",
         "proper-lockfile": "^3.2.0",
         "pull-stream": "^3.6.9",
         "sort-keys": "^2.0.0"
       },
       "dependencies": {
-        "ipfs-block": {
-          "version": "0.7.1",
-          "resolved": "http://registry.npmjs.org/ipfs-block/-/ipfs-block-0.7.1.tgz",
-          "integrity": "sha512-ABZS9J/+OaDwc10zu6pIVdxWnOD/rkPEravk7FRVuRep7/zKSjffNhO/WuHN7Ex+MOBMz7mty0e+i6xjGnRsRQ==",
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
           "requires": {
-            "cids": "^0.5.3",
-            "class-is": "^1.1.0"
+            "lodash": "^4.17.11"
+          }
+        },
+        "cids": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.7.tgz",
+          "integrity": "sha512-SlAz4p8XMEW3mhwiYbzfjn+5+Y//+kIuHqzRUytK0a3uGBnsjJb76xHliehv0HcVMCjRKv2vZnPTwd4QX+IcMA==",
+          "requires": {
+            "class-is": "^1.1.0",
+            "multibase": "~0.6.0",
+            "multicodec": "~0.2.7",
+            "multihashes": "~0.4.14"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
           }
         }
       }
@@ -8675,46 +8849,70 @@
       }
     },
     "ipfs-unixfs-engine": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.33.0.tgz",
-      "integrity": "sha512-NF4e9PB4I22Ca1qaGeCG0pBQOaYTpBWwgC+EKlAomwj6FD6BeFD4OpoaEAs9kp8dOdjY8yKrHe+tRg9AGgOoIw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.35.4.tgz",
+      "integrity": "sha512-6DkrJgPDAWJc1zZSnOqYp6gxe525pnyg2qCxE+PF1KoBz989WWogBrw1h1AfozMrbR5GSrL+peSgg34WAlE8ew==",
+      "requires": {
+        "ipfs-unixfs-exporter": "~0.35.4",
+        "ipfs-unixfs-importer": "~0.38.0"
+      }
+    },
+    "ipfs-unixfs-exporter": {
+      "version": "0.35.9",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-0.35.9.tgz",
+      "integrity": "sha512-a0faOzE2VfOsW/9MiXhstHRK1YAO/k8YVHN9PGsewsyAeZNL+/dLFqHbYmBcbg31tEmYYluBea9Dr7whw4+Dqg==",
       "requires": {
         "async": "^2.6.1",
         "cids": "~0.5.5",
-        "deep-extend": "~0.6.0",
+        "hamt-sharding": "0.0.2",
         "ipfs-unixfs": "~0.1.16",
-        "ipld-dag-pb": "~0.14.11",
+        "ipfs-unixfs-importer": "~0.38.0",
+        "pull-cat": "^1.1.11",
+        "pull-defer": "~0.2.3",
+        "pull-paramap": "^1.2.2",
+        "pull-stream": "^3.6.9",
+        "pull-traverse": "^1.0.3"
+      }
+    },
+    "ipfs-unixfs-importer": {
+      "version": "0.38.4",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-0.38.4.tgz",
+      "integrity": "sha512-S9XlPLRF2KAIBvdOMjZfhUVFatFFrFxa6osDZqnSOXh1B+oBiRnCr0hXwQ7l0FQV6n4qljn0UCSlBBCO12lYOQ==",
+      "requires": {
+        "async": "^2.6.1",
+        "async-iterator-to-pull-stream": "^1.1.0",
+        "bl": "^2.1.2",
+        "deep-extend": "~0.6.0",
+        "hamt-sharding": "~0.0.2",
+        "ipfs-unixfs": "~0.1.16",
+        "ipld-dag-pb": "~0.15.2",
         "left-pad": "^1.3.0",
         "multihashing-async": "~0.5.1",
         "pull-batch": "^1.0.0",
-        "pull-block": "^1.4.0",
-        "pull-cat": "^1.1.11",
         "pull-pair": "^1.1.0",
         "pull-paramap": "^1.2.2",
         "pull-pause": "0.0.2",
         "pull-pushable": "^2.2.0",
         "pull-stream": "^3.6.9",
         "pull-through": "^1.0.18",
-        "pull-traverse": "^1.0.3",
         "pull-write": "^1.1.4",
         "rabin": "^1.6.0",
-        "sparse-array": "^1.3.1",
         "stream-to-pull-stream": "^1.7.2"
       }
     },
     "ipld": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.19.3.tgz",
-      "integrity": "sha512-MK7hKGT2bUFs82XjVgM+12RhrAALVAdS/2bXJX4zJR0hPSXe/jXIqv83DijLk98zEjMujoPxh/Er+VVXNSr4gw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.20.2.tgz",
+      "integrity": "sha512-VXGUqcMSfS1L0n8hCFCEbMj86nOkNRCXBihjAlzEOcUbdfdZZsv0wnhgExYCE1JPrCuTqmVV5b/PBfSrhQdMqQ==",
       "requires": {
         "async": "^2.6.1",
         "cids": "~0.5.5",
         "interface-datastore": "~0.6.0",
         "ipfs-block": "~0.8.0",
         "ipfs-block-service": "~0.15.0",
-        "ipfs-repo": "~0.25.0",
+        "ipfs-repo": "~0.26.0",
         "ipld-dag-cbor": "~0.13.0",
-        "ipld-dag-pb": "~0.14.11",
+        "ipld-dag-pb": "~0.15.2",
         "ipld-raw": "^2.0.1",
         "merge-options": "^1.0.1",
         "pull-defer": "~0.2.3",
@@ -8735,12 +8933,11 @@
       }
     },
     "ipld-dag-cbor": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.13.0.tgz",
-      "integrity": "sha512-74gtitUOWbLkGtqomhq7lDYwWzfFNwbwMXAj3jpti4ZtfM9VTJWVIQ+05u7NOCj8yaLwzFONHdcO0rJ+j/i0jA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.13.1.tgz",
+      "integrity": "sha512-96KKh5XUq9LrWE/TQ/BOJ5FcQx7UZ892N76ufDdovq+fIwZ4/YpPRTAVssLUuN3crATHoGu80TVZMgevsuTCdQ==",
       "requires": {
-        "async": "^2.6.1",
-        "borc": "^2.0.3",
+        "borc": "^2.1.0",
         "bs58": "^4.0.1",
         "cids": "~0.5.5",
         "is-circular": "^1.0.2",
@@ -8750,9 +8947,9 @@
       }
     },
     "ipld-dag-pb": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.14.11.tgz",
-      "integrity": "sha512-ja4FH6elDprVuJBkNObFlq7+9h1Q3aoQx5SSG/v3I9e7j19nwyuMhLJYwBhdv29LiqpyD2cEqNrJLm8lWn0lJg==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.15.2.tgz",
+      "integrity": "sha512-9mzeYW4FneGROH+/PXMbXsfy3cUsMYHaI6vUu8nNpSTyQdGF+fa1ViA+jvqWzM8zXYwG4OOSCAAADssJeELAvw==",
       "requires": {
         "async": "^2.6.1",
         "bs58": "^4.0.1",
@@ -8767,34 +8964,44 @@
       }
     },
     "ipld-ethereum": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-2.0.2.tgz",
-      "integrity": "sha512-tKkoBL/Vg4rPJeZu4azbL8t/y6rcF2kfD5kMJ+J/r4Gu+cXkocN9i+A619/00jb+fonm2DgJOtMoSbBk5QfN0Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-2.0.3.tgz",
+      "integrity": "sha512-sJyKMMm8vPXC/cbOwV+f8emJ7FTmT12VYq70FfnNmPSfhtvYRdRtLPKG711KkqPOoTRC+nehQNII2Vwizw/6yg==",
       "requires": {
         "async": "^2.6.0",
         "cids": "~0.5.2",
         "ethereumjs-account": "^2.0.4",
-        "ethereumjs-block": "^2.0.0",
+        "ethereumjs-block": "^2.1.0",
         "ethereumjs-tx": "^1.3.3",
         "ipfs-block": "~0.8.0",
-        "merkle-patricia-tree": "^2.2.0",
+        "merkle-patricia-tree": "^3.0.0",
         "multihashes": "~0.4.12",
         "multihashing-async": "~0.5.1",
         "rlp": "^2.0.0"
       }
     },
     "ipld-git": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.2.2.tgz",
-      "integrity": "sha512-YHS3X9nyyrPeKZZ8S8oui3OysFo3NGyJ9lb4sjXa+hwcuFUHqkfZnQN/NtYuiEixONSoXhZTr6ZAALOccKvShw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.2.3.tgz",
+      "integrity": "sha512-AbIlgbK0vgLqQ/U+kJmnLnK2+uxaMS6PdP/PBK5heBQII3Lb2IpYoMqdJja5wYISTYxGzJeh9PB2U/de3B0ucw==",
       "requires": {
         "async": "^2.6.0",
         "cids": "~0.5.2",
-        "multicodec": "~0.2.5",
+        "multicodec": "~0.4.0",
         "multihashes": "~0.4.12",
         "multihashing-async": "~0.5.1",
         "smart-buffer": "^4.0.0",
         "traverse": "~0.6.6"
+      },
+      "dependencies": {
+        "multicodec": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.4.0.tgz",
+          "integrity": "sha512-npzvuOHRJD172WiolvyF8mAS5JfWWJlVh22OcGZ4I5ZKyFVI4aFQYB5AcMtmMTWRsjiePlOHH/dnaZi8ZidWuA==",
+          "requires": {
+            "varint": "^5.0.0"
+          }
+        }
       }
     },
     "ipld-raw": {
@@ -8819,72 +9026,27 @@
       }
     },
     "ipns": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.3.0.tgz",
-      "integrity": "sha512-3X8xS4AVgRbsqaTfpJ4OzqAJ2DOYXl9lh7AV/gq7qyF14A+YXk1zmCKc6xXS2GJSVkvsnoRsVGPRrQnDQoNksw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.5.0.tgz",
+      "integrity": "sha512-Uf/VWftFnCI0UtjL8VyGRgq62k5PrRzJrA0G43WoIuw7FNk6ggrt+3KAzhlukbYtlHYhOLWwF5eLDllqvurE6g==",
       "requires": {
         "base32-encode": "^1.1.0",
-        "big.js": "^5.1.2",
-        "debug": "^3.1.0",
+        "debug": "^4.1.1",
         "interface-datastore": "~0.6.0",
         "left-pad": "^1.3.0",
-        "libp2p-crypto": "~0.13.0",
+        "libp2p-crypto": "~0.16.0",
         "multihashes": "~0.4.14",
-        "nano-date": "^2.1.0",
-        "peer-id": "~0.11.0",
-        "protons": "^1.0.1"
+        "peer-id": "~0.12.2",
+        "protons": "^1.0.1",
+        "timestamp-nano": "^1.0.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
-          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
-          "requires": {
-            "async": "^2.6.1",
-            "libp2p-crypto": "~0.13.0",
-            "lodash": "^4.17.10",
-            "multihashes": "~0.4.13"
           }
         }
       }
@@ -9055,7 +9217,8 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -9089,6 +9252,14 @@
       "requires": {
         "global-dirs": "^0.1.0",
         "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
+      "integrity": "sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=",
+      "requires": {
+        "ip-regex": "^2.0.0"
       }
     },
     "is-ipfs": {
@@ -9259,6 +9430,16 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
+    "iso-random-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-1.1.0.tgz",
+      "integrity": "sha512-ywSWt0KrWcsaK0jVoVJIR30rLyjg9Rw3k2Sm/qp+3tdtSV0SNH7L7KilKnENcENOSoJxDFvpt2idvuMMQohdCQ=="
+    },
+    "iso-url": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.6.tgz",
+      "integrity": "sha512-YQO7+aIe6l1aSJUKOx+Vrv08DlhZeLFIVfehG2L29KLSEb9RszqPXilxJRVpp57px36BddKR5ZsebacO5qG0tg=="
+    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -9286,6 +9467,7 @@
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
       "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+      "dev": true,
       "requires": {
         "hoek": "5.x.x",
         "isemail": "3.x.x",
@@ -9296,6 +9478,7 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
           "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+          "dev": true,
           "requires": {
             "punycode": "2.x.x"
           }
@@ -9304,6 +9487,7 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
           "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+          "dev": true,
           "requires": {
             "hoek": "6.x.x"
           },
@@ -9311,7 +9495,8 @@
             "hoek": {
               "version": "6.1.2",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-              "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
+              "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q==",
+              "dev": true
             }
           }
         }
@@ -9323,29 +9508,12 @@
       "integrity": "sha512-TfzJd2JaJ/lg/gU+q5j9rLAjnfUNF9DUmXTP9w+GfmG79LjFOXFeM7hIFuXCBcZCivUDFwd9l1btTV9rhHumtQ=="
     },
     "joi-multiaddr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/joi-multiaddr/-/joi-multiaddr-2.0.0.tgz",
-      "integrity": "sha512-7dJLwgplwRnIQAlC+zTuX3jkk3uXVa/RKm7GDfNO3NqmjiYgwAet8yprIdilki1WhdkJJMLuTNDf49uFNru68A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/joi-multiaddr/-/joi-multiaddr-4.0.0.tgz",
+      "integrity": "sha512-c/QaICFM2nscoHfltv5XBfNBcUNMDBCus5arSwIrMIMJ/yRcKMrzDL1vCtckhtDczajMGkcu1vyRg17rPJsd6g==",
       "requires": {
         "mafmt": "^6.0.0",
-        "multiaddr": "^4.0.0"
-      },
-      "dependencies": {
-        "multiaddr": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
-          "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
-        }
+        "multiaddr": "^6.0.2"
       }
     },
     "js-levenshtein": {
@@ -9370,9 +9538,9 @@
       }
     },
     "js-sha3": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-      "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -9479,12 +9647,16 @@
         "verror": "1.10.0"
       }
     },
+    "just-debounce-it": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/just-debounce-it/-/just-debounce-it-1.1.0.tgz",
+      "integrity": "sha512-87Nnc0qZKgBZuhFZjYVjSraic0x7zwjhaTMrCKlj0QYKH6lh0KbFzVnfu6LHan03NO7J8ygjeBeD0epejn5Zcg=="
+    },
     "k-bucket": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-4.0.1.tgz",
-      "integrity": "sha512-YvDpmY3waI999h1zZoW1rJ04fZrgZ+5PAlVmvwDHT6YO/Q1AOhdel07xsKy9eAvJjQ9xZV1wz3rXKqEfaWvlcQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.0.0.tgz",
+      "integrity": "sha512-r/q+wV/Kde62/tk+rqyttEJn6h0jR7x+incdMVSYTqK73zVxVrzJa70kJL49cIKen8XjIgUZKSvk8ktnrQbK4w==",
       "requires": {
-        "inherits": "^2.0.1",
         "randombytes": "^2.0.3"
       }
     },
@@ -9567,11 +9739,6 @@
         "launch-editor": "^2.2.1"
       }
     },
-    "lazy-cache": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-      "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
-    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -9597,7 +9764,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -9636,7 +9803,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -9666,6 +9833,85 @@
           "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
           "requires": {
             "xtend": "~4.0.0"
+          }
+        }
+      }
+    },
+    "level-mem": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-3.0.1.tgz",
+      "integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
+      "requires": {
+        "level-packager": "~4.0.0",
+        "memdown": "~3.0.0"
+      },
+      "dependencies": {
+        "memdown": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
+          "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
+          "requires": {
+            "abstract-leveldown": "~5.0.0",
+            "functional-red-black-tree": "~1.0.1",
+            "immediate": "~3.2.3",
+            "inherits": "~2.0.1",
+            "ltgt": "~2.2.0",
+            "safe-buffer": "~5.1.1"
+          }
+        }
+      }
+    },
+    "level-packager": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-4.0.1.tgz",
+      "integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
+      "requires": {
+        "encoding-down": "~5.0.0",
+        "levelup": "^3.0.0"
+      },
+      "dependencies": {
+        "deferred-leveldown": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz",
+          "integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
+          "requires": {
+            "abstract-leveldown": "~5.0.0",
+            "inherits": "^2.0.3"
+          }
+        },
+        "level-iterator-stream": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
+          "integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.3.6",
+            "xtend": "^4.0.0"
+          }
+        },
+        "levelup": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz",
+          "integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
+          "requires": {
+            "deferred-leveldown": "~4.0.0",
+            "level-errors": "~2.0.0",
+            "level-iterator-stream": "~3.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         }
       }
@@ -9730,9 +9976,14 @@
             "xtend": "~4.0.0"
           }
         },
+        "bindings": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+          "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
+        },
         "nan": {
           "version": "2.10.0",
-          "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
           "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
         },
         "prebuild-install": {
@@ -9800,154 +10051,118 @@
       }
     },
     "libp2p": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.23.1.tgz",
-      "integrity": "sha512-ArCIJ+EHpeT2qdfEI1Q9sN8oIB0R3Lw7YKLbJKfhK7Mq/+kYug+6RJqgomLJDVDeChTWZa0oe7CB7wEt+IvEpA==",
+      "version": "0.24.4",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.24.4.tgz",
+      "integrity": "sha512-Od6we8H6P/sm3tuJCYFiP/PJ+O6ZNaNw0q5DuNw6obMHgKm/XSsJcDYzgfrPs1P9ASpAMTXAe0cYtjHRoQ9yPQ==",
       "requires": {
         "async": "^2.6.1",
-        "joi": "^13.4.0",
+        "debug": "^4.1.0",
+        "err-code": "^1.1.2",
+        "fsm-event": "^2.1.0",
+        "joi": "^14.0.6",
         "joi-browser": "^13.4.0",
         "libp2p-connection-manager": "~0.0.2",
-        "libp2p-floodsub": "~0.15.0",
-        "libp2p-ping": "~0.8.0",
-        "libp2p-switch": "~0.40.7",
+        "libp2p-floodsub": "~0.15.1",
+        "libp2p-ping": "~0.8.3",
+        "libp2p-switch": "~0.41.3",
         "libp2p-websockets": "~0.12.0",
-        "mafmt": "^6.0.0",
-        "multiaddr": "^5.0.0",
-        "peer-book": "~0.8.0",
-        "peer-id": "~0.11.0",
-        "peer-info": "~0.14.1"
+        "mafmt": "^6.0.2",
+        "multiaddr": "^6.0.2",
+        "peer-book": "~0.9.0",
+        "peer-id": "~0.12.0",
+        "peer-info": "~0.15.0"
       },
       "dependencies": {
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
+        "hoek": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+          "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
+        },
+        "isemail": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+          "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "punycode": "2.x.x"
           }
         },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+        "joi": {
+          "version": "14.3.1",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
+          "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "hoek": "6.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
           }
         },
-        "peer-id": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
-          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
+        "topo": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+          "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
           "requires": {
-            "async": "^2.6.1",
-            "libp2p-crypto": "~0.13.0",
-            "lodash": "^4.17.10",
-            "multihashes": "~0.4.13"
+            "hoek": "6.x.x"
           }
         }
       }
     },
     "libp2p-bootstrap": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.9.4.tgz",
-      "integrity": "sha512-P+UZIwg02Y7ZJQ5ZGAFjXB1ShhxLxGqbwmk2Oke3L8f6h2bywKIY4UQYcqP5+8QvLmD3tX2hXA83kjEh1mNl7g==",
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.9.7.tgz",
+      "integrity": "sha512-GuuYoTh0UBBlph0WuuiewtDZqfYsXmhSdX+JLMzGY6uMuK5aLr7gCa++2zVyBoOIgn0yTq2F6n4vKaWoK9Hi0w==",
       "requires": {
         "async": "^2.6.1",
-        "debug": "^4.1.0",
-        "mafmt": "^6.0.2",
-        "multiaddr": "^5.0.2",
-        "peer-id": "~0.12.0",
-        "peer-info": "~0.14.1"
-      }
-    },
-    "libp2p-circuit": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/libp2p-circuit/-/libp2p-circuit-0.2.1.tgz",
-      "integrity": "sha512-Nr2MyO3onFk1E3hnEtII6MefU7Ps4oPOQ1dcsiFSkoq0NOf2PDCIJ12ySyMfZilmnJbMsGklSVi2fuPyv9PqvA==",
-      "requires": {
-        "async": "^2.6.0",
-        "debug": "^3.1.0",
-        "defaults-deep": "^0.2.4",
-        "interface-connection": "^0.3.2",
-        "mafmt": "^6.0.0",
-        "multiaddr": "^5.0.0",
-        "multistream-select": "^0.14.1",
-        "peer-id": "^0.11.0",
-        "peer-info": "~0.14.1",
-        "protons": "^1.0.1",
-        "pull-abortable": "^4.1.1",
-        "pull-handshake": "^1.1.4",
-        "pull-stream": "^3.6.7"
+        "debug": "^4.1.1",
+        "mafmt": "^6.0.4",
+        "multiaddr": "^6.0.3",
+        "peer-id": "~0.12.2",
+        "peer-info": "~0.15.1"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
+        }
+      }
+    },
+    "libp2p-circuit": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/libp2p-circuit/-/libp2p-circuit-0.3.5.tgz",
+      "integrity": "sha512-uQy4wbpTFyl5YIEpooz1nYISrZj/WLf4R6m/cqhhdCHTFUSAyQsZaeNwxzGqG6dU4APq503+EoPVbQZdjSSw7Q==",
+      "requires": {
+        "async": "^2.6.2",
+        "debug": "^4.1.1",
+        "interface-connection": "~0.3.3",
+        "mafmt": "^6.0.6",
+        "multiaddr": "^6.0.4",
+        "once": "^1.4.0",
+        "peer-id": "~0.12.2",
+        "peer-info": "~0.15.1",
+        "protons": "^1.0.1",
+        "pull-handshake": "^1.1.4",
+        "pull-length-prefixed": "^1.3.1",
+        "pull-pair": "^1.1.0",
+        "pull-stream": "^3.6.9"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "lodash": "^4.17.11"
           }
         },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
-          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
-          "requires": {
-            "async": "^2.6.1",
-            "libp2p-crypto": "~0.13.0",
-            "lodash": "^4.17.10",
-            "multihashes": "~0.4.13"
+            "ms": "^2.1.1"
           }
         }
       }
@@ -9972,266 +10187,165 @@
       }
     },
     "libp2p-crypto": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.14.1.tgz",
-      "integrity": "sha512-JP3bfEzNik76fFIWOeU909+v76tjj5BMukbPCc61bgh1ixftcHkr4bH79duz+oSxRpGA+orCLxvkhgALV+pfwg==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.1.tgz",
+      "integrity": "sha512-+fxqy+cDjwOKK4KTj44WQmjPE5ep2eR5uAIQWHl/+RKvRSor3+RAY53VWkAecgAEvjX2AswxBsoCIJK1Qk5aIQ==",
       "requires": {
+        "asmcrypto.js": "^2.3.2",
         "asn1.js": "^5.0.1",
         "async": "^2.6.1",
+        "bn.js": "^4.11.8",
         "browserify-aes": "^1.2.0",
         "bs58": "^4.0.1",
+        "iso-random-stream": "^1.1.0",
         "keypair": "^1.0.1",
-        "libp2p-crypto-secp256k1": "~0.2.2",
+        "libp2p-crypto-secp256k1": "~0.3.0",
         "multihashing-async": "~0.5.1",
         "node-forge": "~0.7.6",
-        "pem-jwk": "^1.5.1",
+        "pem-jwk": "^2.0.0",
         "protons": "^1.0.1",
         "rsa-pem-to-jwk": "^1.1.3",
         "tweetnacl": "^1.0.0",
-        "ursa-optional": "~0.9.9",
-        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+        "ursa-optional": "~0.9.10"
       }
     },
     "libp2p-crypto-secp256k1": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.2.2.tgz",
-      "integrity": "sha1-DdUh8Yq8TjahUuJOmzYwewrpzwU=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.3.0.tgz",
+      "integrity": "sha512-+rF3S5p2pzS4JLDwVE6gLWZeaKkpl4NkYwG+0knV6ot29UcRSb73OyCWl07r1h5+g9E3KZC3wpsu+RIK5w8zQA==",
       "requires": {
-        "async": "^2.5.0",
-        "multihashing-async": "~0.4.6",
+        "async": "^2.6.1",
+        "bs58": "^4.0.1",
+        "multihashing-async": "~0.5.1",
         "nodeify": "^1.0.1",
-        "safe-buffer": "^5.1.1",
-        "secp256k1": "^3.3.0"
-      },
-      "dependencies": {
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        }
+        "safe-buffer": "^5.1.2",
+        "secp256k1": "^3.6.1"
       }
     },
     "libp2p-floodsub": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.15.2.tgz",
-      "integrity": "sha512-av/0KGr3Ih3KVpRTJ+O7AkhSjPRix0fumP6rXjOtyGi/LQj9PcElnHBWIgs/zqKIOWNhLL64DbmsDrtAo0F3Tw==",
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.15.8.tgz",
+      "integrity": "sha512-tsRTRRz9vg3iPqhSgkn4gotX635Hp/VMxPd4VQZlRvO8pZsfZwd61Qn9Vx8bES881RhRX0YpGM4Sa0izInHEWA==",
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
         "bs58": "^4.0.1",
-        "debug": "^3.1.0",
-        "length-prefixed-stream": "^1.5.2",
-        "libp2p-crypto": "~0.13.0",
-        "lodash": "^4.3.0",
+        "debug": "^4.1.1",
+        "length-prefixed-stream": "^1.6.0",
+        "libp2p-crypto": "~0.16.0",
+        "libp2p-pubsub": "~0.0.1",
         "protons": "^1.0.1",
+        "pull-length-prefixed": "^1.3.1",
         "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.6.9",
         "time-cache": "~0.3.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
           }
         }
       }
     },
     "libp2p-identify": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.7.3.tgz",
-      "integrity": "sha512-RnOXphXxwEzDw8e+aQIE2tqqxXEqZXf457PuzQlOdfMpxDnhHeKObXrjcyfMosyguwJeAzv1x1DJ45ZCXIXFiw==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.7.5.tgz",
+      "integrity": "sha512-sOhCLGjvA8rUa0IqN1BRpm4cfSFTy3VAo0iOBhaOAficNbzSG2bdn9pCCy5F/wXfgEGjByQldMxyNa6eHNyQjg==",
       "requires": {
-        "multiaddr": "^5.0.2",
-        "peer-id": "~0.12.0",
-        "peer-info": "~0.14.1",
+        "multiaddr": "^6.0.3",
+        "peer-id": "~0.12.2",
+        "peer-info": "~0.15.1",
         "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.0",
+        "pull-length-prefixed": "^1.3.1",
         "pull-stream": "^3.6.9"
       }
     },
     "libp2p-kad-dht": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.10.6.tgz",
-      "integrity": "sha512-s94YvwenmqppiC4HdKZiCGfii15zMvVy6hTQ0R+sRWzOazxXUemb59kDS3smsg1Q0IQMDDt5ZD70Y3vGX8onXQ==",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.14.7.tgz",
+      "integrity": "sha512-FM7eZnyPnTtXANDiY9JlG60jyE/2RjukCoV8o44l+3fY9mDguIIx2rjKK9+f0P9OhXEi0hR5w+SLmD5J7DSugQ==",
       "requires": {
-        "async": "^2.6.1",
+        "@nodeutils/defaults-deep": "^1.1.0",
+        "async": "^2.6.2",
         "base32.js": "~0.1.0",
-        "cids": "~0.5.3",
-        "debug": "^3.1.0",
-        "hashlru": "^2.2.1",
+        "chai-checkmark": "^1.0.1",
+        "cids": "~0.5.7",
+        "debug": "^4.1.1",
+        "err-code": "^1.1.2",
+        "hashlru": "^2.3.0",
         "heap": "~0.2.6",
         "interface-datastore": "~0.6.0",
-        "k-bucket": "^4.0.1",
-        "libp2p-crypto": "~0.13.0",
-        "libp2p-record": "~0.6.0",
+        "k-bucket": "^5.0.0",
+        "libp2p-crypto": "~0.16.0",
+        "libp2p-record": "~0.6.2",
         "multihashes": "~0.4.14",
-        "multihashing-async": "~0.5.1",
-        "peer-id": "~0.11.0",
-        "peer-info": "~0.14.1",
+        "multihashing-async": "~0.5.2",
+        "peer-id": "~0.12.2",
+        "peer-info": "~0.15.1",
         "priorityqueue": "~0.2.1",
         "protons": "^1.0.1",
         "pull-length-prefixed": "^1.3.1",
-        "pull-stream": "^3.6.8",
+        "pull-stream": "^3.6.9",
         "varint": "^5.0.0",
         "xor-distance": "^1.0.0"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
+        "cids": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.7.tgz",
+          "integrity": "sha512-SlAz4p8XMEW3mhwiYbzfjn+5+Y//+kIuHqzRUytK0a3uGBnsjJb76xHliehv0HcVMCjRKv2vZnPTwd4QX+IcMA==",
+          "requires": {
+            "class-is": "^1.1.0",
+            "multibase": "~0.6.0",
+            "multicodec": "~0.2.7",
+            "multihashes": "~0.4.14"
+          }
+        },
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-          },
-          "dependencies": {
-            "multihashing-async": {
-              "version": "0.4.8",
-              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-              "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-              "requires": {
-                "async": "^2.6.0",
-                "blakejs": "^1.1.0",
-                "js-sha3": "^0.7.0",
-                "multihashes": "~0.4.13",
-                "murmurhash3js": "^3.0.1",
-                "nodeify": "^1.0.1"
-              }
-            }
-          }
-        },
-        "peer-id": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
-          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
-          "requires": {
-            "async": "^2.6.1",
-            "libp2p-crypto": "~0.13.0",
-            "lodash": "^4.17.10",
-            "multihashes": "~0.4.13"
           }
         }
       }
     },
     "libp2p-keychain": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/libp2p-keychain/-/libp2p-keychain-0.3.3.tgz",
-      "integrity": "sha512-l8HNCowIvyoYiLa0IAJcx48OXlf4KweDaJDbJHeDMuXxOjcGbpuZJfENRuJgNLScjq+eyH8Z52l68IiRJjJCeQ==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/libp2p-keychain/-/libp2p-keychain-0.3.6.tgz",
+      "integrity": "sha512-pwZoPCNyMIhKqMXgCgr87JIjW8H/0I0EtclzHKwQh/Ej5EbZMX/GjvrkBiYplgBvrWFtOl76GokTTvW0bOPB8Q==",
       "requires": {
         "async": "^2.6.1",
         "interface-datastore": "~0.6.0",
-        "libp2p-crypto": "~0.13.0",
-        "lodash": "^4.6.1",
+        "libp2p-crypto": "~0.16.0",
+        "merge-options": "^1.0.1",
+        "node-forge": "~0.7.6",
         "pull-stream": "^3.6.8",
         "sanitize-filename": "^1.6.1"
-      },
-      "dependencies": {
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        }
       }
     },
     "libp2p-mdns": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.12.1.tgz",
-      "integrity": "sha512-WH5ZaHHQ3cvSqvD+CHXo8r+O7shn589/+t6HKPWw79EEa9JyU9T/GWmDd+3VE+ff8PcjPtF3ROdSMei3QIZQUg==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.12.2.tgz",
+      "integrity": "sha512-EDAt4GcRGOp2VkeeeEBU5VSRKv2znnSIBBF1XOkOM/1lbKifrlUiW+9GvXoJJFfrtfAh0F2yQFSAgHD06Y3KcQ==",
       "requires": {
         "libp2p-tcp": "~0.13.0",
-        "multiaddr": "^5.0.2",
+        "multiaddr": "^6.0.2",
         "multicast-dns": "^7.2.0",
         "peer-id": "~0.12.0",
-        "peer-info": "~0.14.1"
+        "peer-info": "~0.15.0"
       }
     },
     "libp2p-mplex": {
@@ -10255,136 +10369,123 @@
       }
     },
     "libp2p-ping": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.8.3.tgz",
-      "integrity": "sha512-8AiUH1FxscWmfZY5EpbEBHp5C2VLmfB4kdBD7pjiMhiv+DkYJkMBAMOD88703wSbldiuEys9shw8BxeDljr7wQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.8.5.tgz",
+      "integrity": "sha512-BzCN3+jp1SvJQZlXq2G3TMkyK5UOOf3JO+CZMnaUEHYlRgQf2zShYta5XU2IGx0EJA/23iCdCL+LjBP/DOvbkQ==",
       "requires": {
-        "libp2p-crypto": "~0.14.1",
+        "libp2p-crypto": "~0.16.0",
         "pull-handshake": "^1.1.4",
         "pull-stream": "^3.6.9"
       }
     },
-    "libp2p-record": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.6.1.tgz",
-      "integrity": "sha512-GUZ0kQTHFpxeljJhW5f1PnmwW2A0qU9NmF3TP4xkZDmJs3HqawrYovVr9ROGNEPI4ovwjZkJSuG+an3QCQxXWA==",
+    "libp2p-pubsub": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.0.2.tgz",
+      "integrity": "sha512-1/ZzP+QmEG/J1D20JKORar9H1QgNLvFVHnaGPSWt0D4oGtzY790oRSyybYFEV+tkshii/gm74na5UmDHL/1q7g==",
       "requires": {
-        "async": "^2.5.0",
-        "buffer-split": "^1.0.0",
+        "async": "^2.6.1",
+        "debug": "^4.1.1",
         "err-code": "^1.1.2",
-        "left-pad": "^1.1.3",
-        "multihashes": "~0.4.14",
-        "multihashing-async": "~0.4.6",
-        "protons": "^1.0.0"
+        "length-prefixed-stream": "^1.6.0",
+        "protons": "^1.0.1",
+        "pull-pushable": "^2.2.0",
+        "time-cache": "~0.3.0"
       },
       "dependencies": {
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "libp2p-record": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.6.2.tgz",
+      "integrity": "sha512-b+RQc4l6AzYtQq0kAyDYV2Eth1DDsB2TQoQfvQtyJy/iVeKz8Q1RZxLTo7lhwS78LMwcVCGrdlx5H5luONjhjg==",
+      "requires": {
+        "async": "^2.6.2",
+        "buffer-split": "^1.0.0",
+        "err-code": "^1.1.2",
+        "left-pad": "^1.3.0",
+        "multihashes": "~0.4.14",
+        "multihashing-async": "~0.5.2",
+        "protons": "^1.0.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "requires": {
+            "lodash": "^4.17.11"
           }
         }
       }
     },
     "libp2p-secio": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.10.1.tgz",
-      "integrity": "sha512-zfryPonQ2GMhGBaF28/fHK2luLFgCfK2NBX1hJBcX7FaxQI7vfNo11Ks3Dm0LIzoKLpFBOOyZqeJ3ewJi/pgnw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.11.1.tgz",
+      "integrity": "sha512-PMVlLutZcCpaNMQZbsbADUR6BWAFuB7ap8fc006YFj3uRQpq8HEVW6DsYlNVG6QQm9JMdvaitfgLTaDFqw5bVg==",
       "requires": {
         "async": "^2.6.1",
-        "debug": "^4.1.0",
+        "debug": "^4.1.1",
         "interface-connection": "~0.3.2",
-        "libp2p-crypto": "~0.14.0",
-        "multihashing-async": "~0.5.1",
-        "peer-id": "~0.12.0",
-        "peer-info": "~0.14.1",
+        "libp2p-crypto": "~0.16.0",
+        "multihashing-async": "~0.5.2",
+        "peer-id": "~0.12.2",
+        "peer-info": "~0.15.1",
         "protons": "^1.0.1",
         "pull-defer": "~0.2.3",
         "pull-handshake": "^1.1.4",
         "pull-length-prefixed": "^1.3.1",
         "pull-stream": "^3.6.9"
-      }
-    },
-    "libp2p-switch": {
-      "version": "0.40.8",
-      "resolved": "https://registry.npmjs.org/libp2p-switch/-/libp2p-switch-0.40.8.tgz",
-      "integrity": "sha512-+xCO9qyFanPP93rg5ft/o+VvAUw6LanSpZVO+vMdaFP+EoLp7INzJTAKZC7FSF6HhuVqhpUd/Y8/fvPi6mZ4Yw==",
-      "requires": {
-        "async": "^2.6.1",
-        "big.js": "^5.1.2",
-        "debug": "^3.1.0",
-        "hashlru": "^2.2.1",
-        "interface-connection": "~0.3.2",
-        "ip-address": "^5.8.9",
-        "libp2p-circuit": "~0.2.1",
-        "libp2p-identify": "~0.7.2",
-        "lodash.includes": "^4.3.0",
-        "moving-average": "^1.0.0",
-        "multiaddr": "^5.0.0",
-        "multistream-select": "~0.14.3",
-        "once": "^1.4.0",
-        "peer-id": "~0.11.0",
-        "peer-info": "~0.14.1",
-        "pull-stream": "^3.6.9"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
+        }
+      }
+    },
+    "libp2p-switch": {
+      "version": "0.41.5",
+      "resolved": "https://registry.npmjs.org/libp2p-switch/-/libp2p-switch-0.41.5.tgz",
+      "integrity": "sha512-bKfkFsEiRXfc3+2Fcbep9WtuuNzKKQziHH5PkQWihn+BVh5UrUGXoWCip/YwsGV7CcGI2zhp3qAmBJ+Cde9EDg==",
+      "requires": {
+        "async": "^2.6.1",
+        "bignumber.js": "^8.0.1",
+        "class-is": "^1.1.0",
+        "debug": "^4.1.1",
+        "err-code": "^1.1.2",
+        "fsm-event": "^2.1.0",
+        "hashlru": "^2.3.0",
+        "interface-connection": "~0.3.3",
+        "libp2p-circuit": "~0.3.4",
+        "libp2p-identify": "~0.7.5",
+        "moving-average": "^1.0.0",
+        "multiaddr": "^6.0.3",
+        "multistream-select": "~0.14.4",
+        "once": "^1.4.0",
+        "peer-id": "~0.12.2",
+        "peer-info": "~0.15.1",
+        "pull-stream": "^3.6.9",
+        "retimer": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
-          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
-          "requires": {
-            "async": "^2.6.1",
-            "libp2p-crypto": "~0.13.0",
-            "lodash": "^4.17.10",
-            "multihashes": "~0.4.13"
+            "ms": "^2.1.1"
           }
         }
       }
@@ -10413,28 +10514,42 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "multiaddr": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.2.tgz",
+          "integrity": "sha512-dXz1chaUHV6L6okujDLS7uRA6NmCbitpikOJA0vMMnrwVyai5kC3ot2CSLrSfj3B8XIgNzpe/j5auSYrnbGGzA==",
+          "requires": {
+            "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
+            "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
+            "lodash.filter": "^4.6.0",
+            "lodash.map": "^4.6.0",
+            "varint": "^5.0.0",
+            "xtend": "^4.0.1"
+          }
         }
       }
     },
     "libp2p-webrtc-star": {
-      "version": "0.15.6",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.15.6.tgz",
-      "integrity": "sha512-BsWhqLRRMPa2QQJUkVOkWXCl7OP2/+lBQJDkjfk71lfb2OCzcRkhiZXgAxKCVpZucvBnSbRpmW6uI+6xdiItgQ==",
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.15.8.tgz",
+      "integrity": "sha512-ONfDf0DCamO++xZRJsPA2SSlrutO+UxC80t56acShg6ViZItiY3Y1WaMO+87jVW2711x230NlmOVoQ/gHfJmVw==",
       "requires": {
         "async": "^2.6.1",
         "class-is": "^1.1.0",
         "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
         "epimetheus": "^1.0.92",
         "hapi": "^16.6.2",
         "inert": "^4.2.1",
         "interface-connection": "~0.3.2",
-        "mafmt": "^6.0.2",
+        "mafmt": "^6.0.4",
         "minimist": "^1.2.0",
-        "multiaddr": "^5.0.2",
+        "multiaddr": "^6.0.3",
         "once": "^1.4.0",
-        "peer-id": "~0.12.0",
-        "peer-info": "~0.14.1",
+        "peer-id": "~0.12.2",
+        "peer-info": "~0.15.1",
         "pull-stream": "^3.6.9",
         "simple-peer": "^9.1.2",
         "socket.io": "^2.1.1",
@@ -10444,38 +10559,70 @@
       }
     },
     "libp2p-websocket-star": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/libp2p-websocket-star/-/libp2p-websocket-star-0.9.1.tgz",
-      "integrity": "sha512-OdQ31meWB5uisi69xNS+ePfrY+ebwNNnm2mgCynZhBvgUvglZscb5HpOQ4Syg4AwyUrZUlCPblW6jmIBPtUFBQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/libp2p-websocket-star/-/libp2p-websocket-star-0.10.2.tgz",
+      "integrity": "sha512-ccjMqy7lrKV6vbTdsm9XOZ+eWt01ZCS3hI2s+I+ZpglnPQNg8z+dGs+8rdl8/hU44Sq3EbmUw0gCxPB/2ZbPlg==",
       "requires": {
         "async": "^2.6.1",
         "class-is": "^1.1.0",
-        "data-queue": "0.0.3",
-        "debug": "^4.1.0",
+        "debug": "^4.1.1",
         "interface-connection": "~0.3.2",
-        "libp2p-crypto": "~0.14.1",
-        "mafmt": "^6.0.2",
-        "merge-recursive": "0.0.3",
-        "multiaddr": "^5.0.2",
+        "libp2p-crypto": "~0.16.0",
+        "mafmt": "^6.0.4",
+        "multiaddr": "^6.0.3",
+        "nanoid": "^2.0.0",
         "once": "^1.4.0",
-        "peer-id": "~0.12.0",
-        "peer-info": "~0.14.1",
+        "peer-id": "~0.12.2",
+        "peer-info": "~0.15.1",
         "pull-stream": "^3.6.9",
         "socket.io-client": "^2.1.1",
-        "socket.io-pull-stream": "~0.1.5",
-        "uuid": "^3.3.2"
+        "socket.io-pull-stream": "~0.1.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "libp2p-websocket-star-multi": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/libp2p-websocket-star-multi/-/libp2p-websocket-star-multi-0.4.3.tgz",
+      "integrity": "sha512-AhiBQABPw0uCRX4T1XzixRvCRXIq3k/IqrXcdRLgBZ8Yi6SXl0l7YwfAv5bO4fjq+jJTj2ypPvyM16ftNnWqBw==",
+      "requires": {
+        "async": "^2.6.1",
+        "debug": "^4.1.0",
+        "libp2p-websocket-star": "~0.10.2",
+        "mafmt": "^6.0.2",
+        "multiaddr": "^6.0.3",
+        "once": "^1.4.0"
       }
     },
     "libp2p-websockets": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.12.0.tgz",
-      "integrity": "sha512-I4m0MNqzBOwoIneCF/5mXHGaavNf0Hoe/7NFg2WUm74o7240dZEIuNkAoLu1+OJyOPyu4RXeIBhUOS4cjBdCew==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.12.2.tgz",
+      "integrity": "sha512-K/Jg/fWFfP5NyiLx01EJcoAcYQO00RSHpZfPQDR3May6ABvOseAjq45SrUDdDCW5mCS0502Vz1VjRrZdOXw8zQ==",
       "requires": {
         "class-is": "^1.1.0",
+        "debug": "^4.1.1",
         "interface-connection": "~0.3.2",
-        "lodash.includes": "^4.3.0",
-        "mafmt": "^6.0.0",
-        "pull-ws": "^3.3.1"
+        "mafmt": "^6.0.4",
+        "multiaddr-to-uri": "^4.0.1",
+        "pull-ws": "github:hugomrdias/pull-ws#8e2ce0bb3b1cd6804828316e937fff8e0bef6225"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "load-json-file": {
@@ -10611,11 +10758,6 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
-    "lodash.groupby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
-      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
-    },
     "lodash.has": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
@@ -10635,11 +10777,6 @@
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
       "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
-    },
-    "lodash.isundefined": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
-      "integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g="
     },
     "lodash.map": {
       "version": "4.6.0",
@@ -10673,16 +10810,6 @@
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
     },
-    "lodash.pullallwith": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.pullallwith/-/lodash.pullallwith-4.7.0.tgz",
-      "integrity": "sha1-ZX5CAHENi1nWlO5SE2Yq4FEdEXA="
-    },
-    "lodash.range": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.range/-/lodash.range-3.2.0.tgz",
-      "integrity": "sha1-9GHliPZmg/fq3q3lE+OKaaVloV0="
-    },
     "lodash.repeat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
@@ -10692,11 +10819,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
-    },
-    "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "lodash.throttle": {
       "version": "4.1.1",
@@ -10714,21 +10836,6 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
-    },
-    "lodash.uniqby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
-    },
-    "lodash.uniqwith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
-      "integrity": "sha1-egy/ZfQ7WShiWp1NDcVLGMrcfvM="
-    },
-    "lodash.values": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
-      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c="
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -10785,28 +10892,11 @@
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
     "mafmt": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.3.tgz",
-      "integrity": "sha512-VtaYiM1oQu3zmT9iejn2fFkAse1PtG1ytWr+AqeydTqpIpnYp9ycipQEJSP9yeZnQSqVmXVlErkgjG4WnAkk8A==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.7.tgz",
+      "integrity": "sha512-2OG/EGAJZmpZBl7YRT1hD83sZa2gKsUEdegRuURreIOe7B4VeHU1rYYmhgk7BkLzknGL3xGYsDx3bbSgEEzE7g==",
       "requires": {
-        "multiaddr": "^6.0.0"
-      },
-      "dependencies": {
-        "multiaddr": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.0.0.tgz",
-          "integrity": "sha512-2jZgvRFd2C7cNV6l0O5232/ZEnKN6PO+7xDw0haJ/Uh92Zgna6K98JvLykBodMXwXcbTY8j9kxu8Zi6NYGpuMQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
-        }
+        "multiaddr": "^6.0.4"
       }
     },
     "make-dir": {
@@ -10830,11 +10920,6 @@
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
-    },
-    "map-or-similar": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
-      "integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -10905,14 +10990,6 @@
         }
       }
     },
-    "memoizerific": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
-      "integrity": "sha1-fIekZGREwy11Q4VwkF8tvRsagFo=",
-      "requires": {
-        "map-or-similar": "^1.5.0"
-      }
-    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -10954,11 +11031,6 @@
         "is-plain-obj": "^1.1"
       }
     },
-    "merge-recursive": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/merge-recursive/-/merge-recursive-0.0.3.tgz",
-      "integrity": "sha1-3nkB78rsyQbYyrKtHpxHD1o9roQ="
-    },
     "merge-source-map": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
@@ -10988,135 +11060,44 @@
       "integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY="
     },
     "merkle-patricia-tree": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-3.0.0.tgz",
+      "integrity": "sha512-soRaMuNf/ILmw3KWbybaCjhx86EYeBbD8ph0edQCTed0JN/rxDt1EBN52Ajre3VyGo+91f8+/rfPIRQnnGMqmQ==",
       "requires": {
-        "async": "^1.4.2",
-        "ethereumjs-util": "^5.0.0",
-        "level-ws": "0.0.0",
-        "levelup": "^1.2.1",
-        "memdown": "^1.0.0",
-        "readable-stream": "^2.0.0",
+        "async": "^2.6.1",
+        "ethereumjs-util": "^5.2.0",
+        "level-mem": "^3.0.1",
+        "level-ws": "^1.0.0",
+        "readable-stream": "^3.0.6",
         "rlp": "^2.0.0",
         "semaphore": ">=1.0.1"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+        "level-ws": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-1.0.0.tgz",
+          "integrity": "sha512-RXEfCmkd6WWFlArh3X8ONvQPm8jNpfA0s/36M4QzLqrLEIt1iJE9WBHLZ5vZJK6haMjJPJGJCQWfjMNnRcq/9Q==",
           "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "deferred-leveldown": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-          "requires": {
-            "abstract-leveldown": "~2.6.0"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "level-codec": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
-        },
-        "level-errors": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-          "requires": {
-            "errno": "~0.1.1"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-          "requires": {
-            "inherits": "^2.0.1",
-            "level-errors": "^1.0.3",
-            "readable-stream": "^1.0.33",
-            "xtend": "^4.0.0"
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.8",
+            "xtend": "^4.0.1"
           },
           "dependencies": {
             "readable-stream": {
-              "version": "1.1.14",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             }
           }
-        },
-        "levelup": {
-          "version": "1.3.9",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-          "requires": {
-            "deferred-leveldown": "~1.2.1",
-            "level-codec": "~7.0.0",
-            "level-errors": "~1.0.3",
-            "level-iterator-stream": "~1.3.0",
-            "prr": "~1.0.1",
-            "semver": "~5.4.1",
-            "xtend": "~4.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
@@ -11160,7 +11141,8 @@
     "mime": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.37.0",
@@ -11372,26 +11354,23 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "multiaddr": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.2.tgz",
-      "integrity": "sha512-dXz1chaUHV6L6okujDLS7uRA6NmCbitpikOJA0vMMnrwVyai5kC3ot2CSLrSfj3B8XIgNzpe/j5auSYrnbGGzA==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.0.6.tgz",
+      "integrity": "sha512-nR4s91mi7IKed1jrqUj/4OhZ1VKdAjUG79IuVB5PS6b+qxOZLKPW8nsskHhrfGn4o1Rn1NJWl7znidF/NVQpEA==",
       "requires": {
         "bs58": "^4.0.1",
         "class-is": "^1.1.0",
         "ip": "^1.1.5",
-        "ip-address": "^5.8.9",
-        "lodash.filter": "^4.6.0",
-        "lodash.map": "^4.6.0",
-        "varint": "^5.0.0",
-        "xtend": "^4.0.1"
+        "is-ip": "^2.0.0",
+        "varint": "^5.0.0"
       }
     },
     "multiaddr-to-uri": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-4.0.0.tgz",
-      "integrity": "sha512-uxaH4LxjqcUyusDK+iSBNu/PCSHr2zBS4lKABA4upCXkfxQliE3/DMjuuBydIT2zY2MyYLONtvdoXgJgzgKGHg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-4.0.1.tgz",
+      "integrity": "sha512-RVHKm5NXcMWMIhrwF4B4Q34JtMXt1/2wgnDTnKRE+AGAiXfqFika0bIfCsAtLp+gZJOWeDLeT1vR6P0gGyVAtg==",
       "requires": {
-        "multiaddr": "^5.0.0"
+        "multiaddr": "^6.0.3"
       }
     },
     "multibase": {
@@ -11435,44 +11414,31 @@
       }
     },
     "multihashing-async": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
-      "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
+      "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
       "requires": {
-        "async": "^2.6.1",
         "blakejs": "^1.1.0",
-        "js-sha3": "^0.7.0",
+        "js-sha3": "~0.8.0",
         "multihashes": "~0.4.13",
         "murmurhash3js": "^3.0.1",
         "nodeify": "^1.0.1"
       }
     },
     "multistream-select": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-0.14.3.tgz",
-      "integrity": "sha512-Wu2ulJtUv5DWrilQ3I3rMRd+zdN8K+fZGX09UYfBGr9ZFLeiukCKvftkTiF6j7viCDNDS5VnjwVqwjrLwoS06g==",
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-0.14.4.tgz",
+      "integrity": "sha512-pWC3AOtcJXXUtN+GpY66enRN0Qrw51mFuzhxs9TjVcjSllpA3bGYkwBlORUHiVjSTxBGZy7mR4VbsBDGrhQV3g==",
       "requires": {
         "async": "^2.6.0",
-        "debug": "^3.1.0",
+        "debug": "^4.1.0",
         "interface-connection": "~0.3.2",
-        "lodash.isfunction": "^3.0.9",
-        "lodash.range": "^3.2.0",
         "once": "^1.4.0",
         "pull-handshake": "^1.1.4",
         "pull-length-prefixed": "^1.3.1",
         "pull-stream": "^3.6.7",
         "semver": "^5.5.0",
         "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "murmurhash3js": {
@@ -11491,27 +11457,10 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
       "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
     },
-    "nano-date": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nano-date/-/nano-date-2.1.0.tgz",
-      "integrity": "sha1-veghPYoPKtGjoW6PRV7uJHX/2/k=",
-      "requires": {
-        "bignumber.js": "^4.0.4",
-        "core-decorators": "^0.20.0",
-        "memoizerific": "^1.11.2"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-          "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
-        }
-      }
-    },
     "nanoid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.0.tgz",
-      "integrity": "sha512-SG2qscLE3iM4C0CNzGrsAojJHSVHMS1J8NnvJ31P1lH8P0hGHOiafmniNJz6w6q7vuoDlV7RdySlJgtqkFEVtQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.1.tgz",
+      "integrity": "sha512-k1u2uemjIGsn25zmujKnotgniC/gxQ9sdegdezeDiKdkDW56THUMqlz3urndKCXJxA6yPzSZbXx/QCMe/pxqsA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -11591,12 +11540,17 @@
       }
     },
     "node-abi": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.5.0.tgz",
-      "integrity": "sha512-9g2twBGSP6wIR5PW7tXvAWnEWKJDH/VskdXp168xsw9VVxpEGov8K4jsP4/VeoC7b2ZAyzckvMCuQuQlw44lXg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.7.1.tgz",
+      "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
       "requires": {
         "semver": "^5.4.1"
       }
+    },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
     "node-forge": {
       "version": "0.7.6",
@@ -12039,7 +11993,8 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-defer": {
       "version": "1.0.0",
@@ -12271,204 +12226,43 @@
       }
     },
     "peer-book": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.8.0.tgz",
-      "integrity": "sha512-0An5viX2NnYeaqmwe2Vpzl03K9yxJ08mrktzkCPJyyd6rO4xz6QV2JK2Ku2vTHATP8Ag0ambxvr0QbrkT4UCYA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.9.1.tgz",
+      "integrity": "sha512-Bnhsrruilysw5nFU0V2hcTmLnT2cRfc6mud62aaG1dkh9J8IkQ83IclcC2ziVPnEi8AFX8SQ1sSG7Qe0JTwIBA==",
       "requires": {
         "bs58": "^4.0.1",
-        "peer-id": "^0.10.7",
-        "peer-info": "^0.14.1"
-      },
-      "dependencies": {
-        "libp2p-crypto": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.10.7",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
-          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
-          "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
-          }
-        }
+        "peer-id": "~0.12.2",
+        "peer-info": "~0.15.1"
       }
     },
     "peer-id": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.12.0.tgz",
-      "integrity": "sha512-pPKk4IDBWGGzcjXe6zzngIwKmyadYNsIOUH1PKb7GYTVVTKHpHn78ljZNZdAXAWZ2V1TmlU2OS6d9MfW2E5DNA==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.12.2.tgz",
+      "integrity": "sha512-pked3yPLcOcprH21OnYbJAzk9OgI/TDEqjJ0IfRJSVB/61ZyqU5VKO7cw7hul+YD8nTD79wM79xFRWN3f6otNg==",
       "requires": {
         "async": "^2.6.1",
         "class-is": "^1.1.0",
-        "libp2p-crypto": "~0.13.0",
-        "lodash": "^4.17.10",
+        "libp2p-crypto": "~0.16.0",
         "multihashes": "~0.4.13"
-      },
-      "dependencies": {
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        }
       }
     },
     "peer-info": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.14.1.tgz",
-      "integrity": "sha512-I9K+q7sisU0gg5ej6ekbhgolwlcm1tc2wDtLmumptoLYx0DkIT8WVHtgoTnupYwRRqcYADtwddFdiXfb8QFqzg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.15.1.tgz",
+      "integrity": "sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==",
       "requires": {
-        "lodash.uniqby": "^4.7.0",
-        "mafmt": "^6.0.0",
-        "multiaddr": "^4.0.0",
-        "peer-id": "~0.10.7"
-      },
-      "dependencies": {
-        "libp2p-crypto": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-          }
-        },
-        "multiaddr": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
-          "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.10.7",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
-          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
-          "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
-          }
-        }
+        "mafmt": "^6.0.2",
+        "multiaddr": "^6.0.3",
+        "peer-id": "~0.12.2",
+        "unique-by": "^1.0.0"
       }
     },
     "pem-jwk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.5.1.tgz",
-      "integrity": "sha1-eoY3/S9nqCflfAxC4cI8P9Us+wE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-2.0.0.tgz",
+      "integrity": "sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==",
       "requires": {
-        "asn1.js": "1.0.3"
-      },
-      "dependencies": {
-        "asn1.js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
-          "integrity": "sha1-KBuj7B8kSP52X5Kk7s+IP+E2S1Q=",
-          "requires": {
-            "bn.js": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "bn.js": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
-          "integrity": "sha1-DbTL+W+PI7dC9by50ap6mZSgXoM=",
-          "optional": true
-        }
+        "asn1.js": "^5.0.1"
       }
     },
     "performance-now": {
@@ -13276,9 +13070,9 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "prom-client": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.2.0.tgz",
-      "integrity": "sha512-4gUAq/GR5C8q5eWxOa7tA60AtmkMpbyBd/2btCayvd3h/7HzS0p/kESKRwggJgbFrfdhTCBpOwPAwKiI01Q0VQ==",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.2.1.tgz",
+      "integrity": "sha512-7VwtjrkQS50NvDoeYNn2z6wzXB5BMGzUlmMOeLPaITtJsTVXnPywRta7QFiV4pKr0fbRx9oDfUcx1xibabjSAg==",
       "optional": true,
       "requires": {
         "tdigest": "^0.1.1"
@@ -13397,23 +13191,15 @@
         "pull-through": "^1.0.18"
       }
     },
-    "pull-block": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/pull-block/-/pull-block-1.4.0.tgz",
-      "integrity": "sha512-nqrFveL9SWdpM9FDkgUVifhbH/dgtK65Pmwa/rrdvB9avE32uWXb1uiemxczfrkqZaG4XVc139KdqfyvPoraoA==",
-      "requires": {
-        "pull-through": "^1.0.18"
-      }
-    },
     "pull-cat": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
       "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs="
     },
     "pull-catch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pull-catch/-/pull-catch-1.0.0.tgz",
-      "integrity": "sha1-9YA361woLMtQavn3awAn0zkx5Is="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pull-catch/-/pull-catch-1.0.1.tgz",
+      "integrity": "sha512-wrKbmEYySNETxOYXDTCJ8L/rcAFMayOifne2a+X9C0wSm6ttIWHHXwMYQh6k8iDRvtMM8itYkBlP4leKBJTiKA=="
     },
     "pull-defer": {
       "version": "0.2.3",
@@ -13525,6 +13311,14 @@
       "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
       "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
     },
+    "pull-stream-to-async-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pull-stream-to-async-iterator/-/pull-stream-to-async-iterator-1.0.1.tgz",
+      "integrity": "sha512-jbFoG4yVScxBYGWdwL/NyvuQug6uuBOyeAUsKkUFdZQsZQLBemZU9pFSbY8ZAJrUzHFRPpi6uKR10+EIuNZmMA==",
+      "requires": {
+        "pull-stream": "^3.6.9"
+      }
+    },
     "pull-stream-to-stream": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/pull-stream-to-stream/-/pull-stream-to-stream-1.3.4.tgz",
@@ -13571,19 +13365,14 @@
       }
     },
     "pull-ws": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.3.1.tgz",
-      "integrity": "sha512-kJodbLQT+oKjcRIQO+vQNw6xWBuEo7Kxp51VMOvb6cvPvHYA+aNLzm+NmkB/5dZwbuTRYGMal9QPvH52tzM1ZA==",
+      "version": "github:hugomrdias/pull-ws#8e2ce0bb3b1cd6804828316e937fff8e0bef6225",
+      "from": "github:hugomrdias/pull-ws#fix/bundle-size",
       "requires": {
+        "iso-url": "^0.4.4",
         "relative-url": "^1.0.2",
         "safe-buffer": "^5.1.1",
         "ws": "^1.1.0"
       }
-    },
-    "pull-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pull-zip/-/pull-zip-2.0.1.tgz",
-      "integrity": "sha1-4GQc6v+WSvJ1ltqsBwDnmzgQKPU="
     },
     "pump": {
       "version": "3.0.0",
@@ -13676,7 +13465,7 @@
       "dependencies": {
         "bl": {
           "version": "1.2.2",
-          "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "optional": true,
           "requires": {
@@ -13701,7 +13490,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -13954,11 +13743,6 @@
       "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
       "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc="
     },
-    "remedial": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
-      "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg=="
-    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -14171,6 +13955,11 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "retimer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-2.0.0.tgz",
+      "integrity": "sha512-KLXY85WkEq2V2bKex/LOO1ViXVn2KGYe4PYysAdYdjmraYIUsVkXu8O4am+8+5UbaaGl1qho4aqAAPHNQ4GSbg=="
+    },
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -14191,7 +13980,8 @@
     "rimraf": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "dev": true
     },
     "ripemd160": {
       "version": "2.0.2",
@@ -14203,10 +13993,11 @@
       }
     },
     "rlp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.1.0.tgz",
-      "integrity": "sha512-93U7IKH5j7nmXFVg19MeNBGzQW5uXW1pmCuKY8veeKIhYTE32C2d0mOegfiIAfXcHOKJjjPlJisn8iHDF5AezA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.2.tgz",
+      "integrity": "sha512-Ng2kJEN731Sfv4ZAY2i0ytPMc0BbJKBsVNl0QZY8LxOWSwd+1xpg+fpSRfaMn0heHU447s6Kgy8qfHZR0XTyVw==",
       "requires": {
+        "bn.js": "^4.11.1",
         "safe-buffer": "^5.1.1"
       }
     },
@@ -14330,9 +14121,9 @@
       }
     },
     "secp256k1": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.2.tgz",
-      "integrity": "sha512-iin3kojdybY6NArd+UFsoTuapOF7bnJNf2UbcWXaY3z+E1sJDipl60vtzB5hbO/uquBu7z0fd4VC4Irp+xoFVQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.6.2.tgz",
+      "integrity": "sha512-90nYt7yb0LmI4A2jJs1grglkTAXrBwxYAjP9bpeKjvJKOjG2fOeH/YI/lchDMIvjrOasd5QXwvV2jwN168xNng==",
       "requires": {
         "bindings": "^1.2.1",
         "bip66": "^1.1.3",
@@ -14622,28 +14413,20 @@
       }
     },
     "simple-peer": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.1.2.tgz",
-      "integrity": "sha512-MUWWno5o5cvISKOH4pYQ18PQJLpDaNWoKUbrPPKuspCLCkkh+zhtuQyTE8h2U2Ags+/OUN5wnUe92+9B8/Sm2Q==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.2.1.tgz",
+      "integrity": "sha512-NDAQefJCcmpni/csZgBEBDyDglTMBJOoZSl3pUQTWud+jqy02CX8LMz8Ys9qVLmm1D4IW/NP24pM9vKK0MRgXQ==",
       "requires": {
-        "debug": "^3.1.0",
+        "debug": "^4.0.1",
         "get-browser-rtc": "^1.0.0",
         "inherits": "^2.0.1",
         "randombytes": "^2.0.3",
         "readable-stream": "^2.3.4"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -14690,9 +14473,9 @@
       }
     },
     "smart-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.1.tgz",
-      "integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
+      "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -14975,7 +14758,7 @@
       "dependencies": {
         "hoek": {
           "version": "4.2.1",
-          "resolved": "http://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
           "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
         }
       }
@@ -15179,16 +14962,17 @@
       "dev": true
     },
     "statehood": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/statehood/-/statehood-5.0.3.tgz",
-      "integrity": "sha512-YrPrCt10t3ImH/JMO5szSwX7sCm8HoqVl3VFLOa9EZ1g/qJx/ZmMhN+2uzPPB/vaU6hpkJpXxcBWsgIkkG+MXA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/statehood/-/statehood-5.0.4.tgz",
+      "integrity": "sha512-6/feFLqqHylvA/dHwJA0DgXvbEcKgbhRUeljsuu6+cIr8PO88nax7Wc+celZlPTncqT2arsxXL8P329Q1yfe9Q==",
       "requires": {
         "boom": "5.x.x",
+        "bourne": "1.x.x",
         "cryptiles": "3.x.x",
         "hoek": "4.x.x",
         "iron": "4.x.x",
         "items": "2.x.x",
-        "joi": "10.x.x"
+        "joi": "12.x.x"
       },
       "dependencies": {
         "boom": {
@@ -15204,14 +14988,21 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
           "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
         },
+        "isemail": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+          "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+          "requires": {
+            "punycode": "2.x.x"
+          }
+        },
         "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+          "version": "12.0.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-12.0.0.tgz",
+          "integrity": "sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==",
           "requires": {
             "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
+            "isemail": "3.x.x",
             "topo": "2.x.x"
           }
         }
@@ -15431,11 +15222,12 @@
       }
     },
     "subtext": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/subtext/-/subtext-5.0.0.tgz",
-      "integrity": "sha512-2nXG1G1V+K64Z20cQII7k0s38J2DSycMXBLMAk9RXUFG0uAkAbLSVoa88croX9VhTdBCJbLAe9g6LmzKwpJhhQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/subtext/-/subtext-5.0.1.tgz",
+      "integrity": "sha512-zH/jaUKJ/bkrTpEe3zuTFIRnqAwv5xcGpXA2JaxEc30KRAT4k78jZnRqM45snjBSZAuvpI8chRUh1VZprcUVfw==",
       "requires": {
         "boom": "5.x.x",
+        "bourne": "1.x.x",
         "content": "3.x.x",
         "hoek": "4.x.x",
         "pez": "2.x.x",
@@ -15585,7 +15377,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -15608,12 +15400,21 @@
       }
     },
     "temp": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.0.tgz",
+      "integrity": "sha512-YfUhPQCJoNQE5N+FJQcdPz63O3x3sdT4Xju69Gj4iZe0lBKOtnAMi0SLj9xKhGkcGhsxThvTJ/usxtFPo438zQ==",
       "requires": {
-        "os-tmpdir": "^1.0.0",
-        "rimraf": "~2.2.6"
+        "rimraf": "~2.6.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "term-size": {
@@ -15859,6 +15660,11 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "timestamp-nano": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.0.tgz",
+      "integrity": "sha512-NO/1CZigzlCWQiWdIGv8ebXt6Uk77zdLz2NE7KcZRU5Egj2+947lzUpk30xQUQlq5dRY25j7ZulG4RfA2DHYfA=="
+    },
     "timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
@@ -16040,9 +15846,9 @@
       }
     },
     "tweetnacl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
-      "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
+      "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -16077,9 +15883,9 @@
       }
     },
     "typeforce": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.16.0.tgz",
-      "integrity": "sha512-V60F7OHPH7vPlgIU73vYyeebKxWjQqCTlge+MvKlVn09PIhCOi/ZotowYdgREHB5S1dyHOr906ui6NheYXjlVQ=="
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "uglify-js": {
       "version": "3.4.9",
@@ -16184,6 +15990,11 @@
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
+    },
+    "unique-by": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-by/-/unique-by-1.0.0.tgz",
+      "integrity": "sha1-UiDIa6e8Vy+3E610ZRRwy2RCEr0="
     },
     "unique-filename": {
       "version": "1.1.1",
@@ -16640,10 +16451,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "webcrypto-shim": {
-      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-      "from": "github:dignifiedquire/webcrypto-shim#master"
-    },
     "webpack": {
       "version": "4.27.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.27.1.tgz",
@@ -17066,9 +16873,9 @@
       }
     },
     "write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -17234,7 +17041,7 @@
         },
         "elliptic": {
           "version": "3.0.3",
-          "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
           "integrity": "sha1-hlybQgv75VAGuflp+XoNLESWZZU=",
           "requires": {
             "bn.js": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0 AND MIT",
   "private": true,
   "scripts": {
+    "start": "npm run serve",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"
@@ -12,7 +13,7 @@
     "async": "^2.6.1",
     "cids": "^0.5.6",
     "highlight.js": "^9.12.0",
-    "ipfs": "^0.33.1",
+    "ipfs": "^0.34.4",
     "ipfs-css": "^0.6.0",
     "marked": "^0.4.0",
     "monaco-editor": "^0.6.1",

--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -216,7 +216,7 @@ export default {
     exploreIpldUrl: function () {
       let cid = this.output.test && this.output.test.cid && this.output.test.cid.toBaseEncodedString()
       cid = cid || ''
-      return `https://ipfs.io/ipfs/QmYJETQ15RAnKXoJxqpXzcvQ2DuQA35UHwJBTjTPCSs9Ky/#/explore/${cid}`
+      return `https://explore.ipld.io/#/explore/${cid}`
     },
     lessonNumber: function () {
       return parseInt(this.$route.path.slice(this.$route.path.lastIndexOf('/') + 1), 10)

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,6 +2,9 @@ const CopyWebpackPlugin = require('copy-webpack-plugin')
 module.exports = {
   baseUrl: './',
   configureWebpack: config => {
+    config.resolve.alias = {
+      ipfs: 'ipfs/dist/index.min.js'
+    }
     config.plugins.push(
       new CopyWebpackPlugin([
         {


### PR DESCRIPTION
- alias the ipfs dependency to the pre-built bundle.
- update link to explore.ipld.io
- update ipfs to latest release

This ensures the browser friendly ipfs bundle is used. Before this
PR we were seeing a bunch of errors when IPFS tried to init, which
are caused by trying to get webpack to bundle the node build and
not substituting all the browser friendly deps correctly. Luckily,
this work is done for us in the ipfs dist build, so just use that.

<img width="1288" alt="screenshot 2019-03-05 at 22 55 55" src="https://user-images.githubusercontent.com/58871/53843311-dc4b9d80-3f99-11e9-8118-4e8be2972be5.png">

fixes #164
fixes #125

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>