### PR TITLE
Add meta description tag to improve display in search results

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="description" content="ProtoSchool is an educational community that teaches decentralized web protocols and tools through online tutorials and local chapter events."/>
     <link rel="icon" href="<%= BASE_URL %>favicon.png">
     <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
     <title>ProtoSchool</title>


### PR DESCRIPTION
Hopefully avoids showing the `<noscript>` tag when googling for protoschool:
<img width="813" alt="Screenshot 2019-03-26 at 18 24 01" src="https://user-images.githubusercontent.com/1060/55023517-dd9a4400-4ff4-11e9-88fe-d83d6bbdde22.png">
