### PR TITLE
feat: IPFS preview on PR via github action

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -3,14 +3,20 @@ workflow "Build and pin to IPFS" {
   resolves = ["Pin to IPFS Cluster"]
 }
 
-action "Build" {
+action "Install deps" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
-  runs = "/bin/bash -c 'npm ci && npm run build'"
+  args = "ci"
+}
+
+action "Build site" {
+  uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
+  args = "run build"
+  needs = ["Install deps"]
 }
 
 action "Pin to IPFS Cluster" {
   uses = "ipfs-shipyard/ipfs-github-action@master"
-  needs = ["Build"]
   secrets = ["GITHUB_TOKEN", "CLUSTER_USER", "CLUSTER_PASSWORD"]
   args = "/github/workspace/dist"
+  needs = ["Build site"]
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,16 @@
+workflow "Build and pin to IPFS" {
+  on = "push"
+  resolves = ["Pin to IPFS Cluster"]
+}
+
+action "Build" {
+  uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
+  runs = "npm ci && npm run build"
+}
+
+action "Pin to IPFS Cluster" {
+  uses = "ipfs-shipyard/ipfs-github-action@master"
+  needs = ["Build"]
+  secrets = ["GITHUB_TOKEN", "CLUSTER_USER", "CLUSTER_PASSWORD"]
+  args = "/github/workspace/dist"
+}

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -3,7 +3,7 @@ workflow "Build and pin to IPFS" {
   resolves = ["Pin to IPFS Cluster"]
 }
 
-action "Install deps" {
+action "Install" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
   args = "ci"
 }
@@ -11,7 +11,7 @@ action "Install deps" {
 action "Build site" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
   args = "run build"
-  needs = ["Install deps"]
+  needs = ["Install"]
 }
 
 action "Pin to IPFS Cluster" {

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -5,7 +5,7 @@ workflow "Build and pin to IPFS" {
 
 action "Build" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
-  runs = "/bin/bash -c \"npm ci && npm run build\""
+  runs = "/bin/bash -c 'npm ci && npm run build'"
 }
 
 action "Pin to IPFS Cluster" {

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,22 +1,22 @@
-workflow "Build and pin to IPFS" {
+workflow "Publish to IPFS" {
+  resolves = ["pin to cluster"]
   on = "push"
-  resolves = ["Pin to IPFS Cluster"]
 }
 
-action "Install" {
+action "npm install" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
   args = "ci"
 }
 
-action "Build site" {
+action "npm run build" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
   args = "run build"
-  needs = ["Install"]
+  needs = ["npm install"]
 }
 
-action "Pin to IPFS Cluster" {
+action "pin to cluster" {
   uses = "ipfs-shipyard/ipfs-github-action@master"
   secrets = ["GITHUB_TOKEN", "CLUSTER_USER", "CLUSTER_PASSWORD"]
   args = "/github/workspace/dist"
-  needs = ["Build site"]
+  needs = ["npm run build"]
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -5,7 +5,7 @@ workflow "Build and pin to IPFS" {
 
 action "Build" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
-  runs = "npm ci && npm run build"
+  runs = "/bin/bash -c \"npm ci && npm run build\""
 }
 
 action "Pin to IPFS Cluster" {


### PR DESCRIPTION
Build the project then pins the `dist` dir on https://cluster.ipfs.io

An IPFS status will be added to the latest commit in a PR and show up in the status checks box at the bottom as a link to the build out preview on cluster.

fixes #190