### PR TITLE
feat: include ipfs-camp ribbon

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,8 @@
     <meta name="twitter:site" content="@ProtoSchool">
     <link rel="icon" href="<%= BASE_URL %>favicon.png">
     <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+    <!-- ipfs camp -->
+    <script src="https://camp.ipfs.io/ribbon.min.js" async></script>
     <title>ProtoSchool</title>
     <style>
       body {


### PR DESCRIPTION
This implements the IPFS Camp ribbon banner 💅

Currently only visible on larger screen layouts however I may also add a smaller screen variant once I've had chance to evaluate the analytics.

![ribbon-ipfs](https://user-images.githubusercontent.com/106938/56133912-63bb0200-5f85-11e9-877f-826342dcc565.jpg)

ref: protocol/2019-ipfs-camp#13