### PR TITLE
fix: travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ cache:
   directories:
     - node_modules
 before_script:
-  npm install
+  - npm install
 script:
-  npm run build
+  - npm run build
 notifications:
   email: false
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
 before_script:
   npm install
 script:
-  npm test
   npm run build
 notifications:
   email: false


### PR DESCRIPTION
Removes `npm run test` as we don't have any test for now and was breaking the CI for the lack of `-` when running multiple scripts.