### PR TITLE
fix: preserve user code when viewing solution

### DIFF
--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -83,10 +83,13 @@
           </div>
         </div>
         <div class="mb2">
-          <span v-if="solution" @click="viewSolution" class="ml1 fl textLink">View Solution</span>
+          <div v-if="solution">
+            <span v-if="viewSolution" @click="toggleSolution" class="ml1 fl textLink">Hide Solution</span>
+            <span v-else @click="toggleSolution" class="ml1 fl textLink">View Solution</span>
+          </div>
           <span v-if="cachedCode" @click="resetCode" class="mr1 fr textLink">Reset Code</span>
         </div>
-        <div class="h-100 flex-auto bg-white">
+        <div class="h-100 flex-auto">
           <MonacoEditor
             class="editor"
             srcPath="."
@@ -96,8 +99,16 @@
             theme="vs"
             language="javascript"
             @mounted="onMounted"
-            @codeChange="onCodeChange">
-          </MonacoEditor>
+            @codeChange="onCodeChange" />
+
+          <MonacoEditor v-show="viewSolution"
+            class="editor mt3"
+            srcPath="."
+            :height="editorHeight"
+            :options="Object.assign({}, { readOnly: true }, options)"
+            :code="solution"
+            theme="vs-dark"
+            language="javascript" />
         </div>
         <div class='flex-none'>
           <div class="pv2">
@@ -111,7 +122,7 @@
               <div class="lh-copy pv2 ph3 bg-green white" v-if="output.test.success && lessonPassed">
                 {{output.test.success}}
                 <a v-if="output.test.cid"
-                class="link fw7 underline-hover dib ph2 mh2 white"  target='explore-ipld' :href='exploreIpldUrl'>
+                class="link fw7 underline-hover dib ph2 mh2 white" target='explore-ipld' :href='exploreIpldUrl'>
                   View in IPLD Explorer
                 </a>
               </div>
@@ -150,7 +161,7 @@
           </div>
         </div>
       </section>
-      <section v-else >
+      <section v-else>
         <div class="pt3 ph2 tr mb3">
           <div v-if="lessonNumber === lessonsInWorkshop">
             <Button v-bind:click="tutorialMenu" class="bg-aqua white">More Tutorials</Button>
@@ -242,6 +253,7 @@ export default {
       cachedCode: !!localStorage['cached' + self.$route.path],
       code: localStorage[self.cacheKey] || self.$attrs.code || self.defaultCode,
       solution: self.$attrs.solution,
+      viewSolution: false,
       overrideErrors: self.$attrs.overrideErrors,
       isFileLesson: self.isFileLesson,
       parsedText: marked(self.$attrs.text),
@@ -374,12 +386,8 @@ export default {
         delete this.output.test.log
       }
     },
-    viewSolution: function () {
-      // TRACK? User chose to view solution
-      this.editor.setValue(this.$attrs.solution)
-      if (this.output.test) {
-        delete this.output.test
-      }
+    toggleSolution: function () {
+      this.viewSolution = !this.viewSolution
     },
     resetFileUpload: function () {
       this.uploadedFiles = false

--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -96,9 +96,9 @@
             @codeChange="onCodeChange" />
         </div>
         <div class="mt2 h-100 flex-auto">
-          <div v-if="solution" class="mb2">
-            <span v-if="viewSolution" @click="toggleSolution" class="textLink"><span class="chevron up" />Hide Solution</span>
-            <span v-else @click="toggleSolution" class="textLink"><span class="chevron down" />View Solution</span>
+          <div v-if="solution" class="mb2 ml3">
+            <span v-if="viewSolution" @click="toggleSolution" class="textLink chevron down">Hide Solution</span>
+            <span v-else @click="toggleSolution" class="textLink chevron right">View Solution</span>
           </div>
           <MonacoEditor v-show="viewSolution"
             class="editor"
@@ -528,22 +528,34 @@ div#drop-area * {
 }
 
 .chevron {
-  width: 7px;
-  height: 7px;
+  position: relative;
+}
+
+.chevron.down::before {
+  content: '';
+  height: 0px;
+  width: 0px;
+  position: absolute;
+  top: 0;
+  right: 100%;
+  border-color: blue transparent transparent transparent ;
+  border-style: solid;
+  border-width: 5px 5px 5px 5px;
+  margin-top: 8px;
   margin-right: 5px;
-  border: solid blue;
-  border-width: 0 1px 1px 0;
-  display: inline-block;
 }
 
-.chevron.up {
-  margin-bottom: -1px;
-  transform: rotate(225deg);
-}
-
-.chevron.down {
-  margin-bottom: 3px;
-  transform: rotate(45deg);
+.chevron.right::before {
+  content: '';
+  height: 0px;
+  width: 0px;
+  position: absolute;
+  top: 0;
+  right: 100%;
+  border-color: transparent transparent transparent blue;
+  border-style: solid;
+  border-width:  5px 5px 5px;
+  margin-top: 5px;
 }
 </style>
 

--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -82,16 +82,10 @@
             </div>
           </div>
         </div>
-        <div class="mb2">
-          <div v-if="solution">
-            <span v-if="viewSolution" @click="toggleSolution" class="ml1 fl textLink">Hide Solution</span>
-            <span v-else @click="toggleSolution" class="ml1 fl textLink">View Solution</span>
-          </div>
-          <span v-if="cachedCode" @click="resetCode" class="mr1 fr textLink">Reset Code</span>
-        </div>
         <div class="h-100 flex-auto">
+          <span v-if="cachedCode" @click="resetCode" class="textLink">Reset Code</span>
           <MonacoEditor
-            class="editor"
+            class="editor mt2"
             srcPath="."
             :height="editorHeight"
             :options="options"
@@ -100,9 +94,14 @@
             language="javascript"
             @mounted="onMounted"
             @codeChange="onCodeChange" />
-
+        </div>
+        <div class="mt2 h-100 flex-auto">
+          <div v-if="solution" class="mb2">
+            <span v-if="viewSolution" @click="toggleSolution" class="textLink"><span class="chevron up" />Hide Solution</span>
+            <span v-else @click="toggleSolution" class="textLink"><span class="chevron down" />View Solution</span>
+          </div>
           <MonacoEditor v-show="viewSolution"
-            class="editor mt3"
+            class="editor"
             srcPath="."
             :height="editorHeight"
             :options="Object.assign({}, { readOnly: true }, options)"
@@ -111,7 +110,7 @@
             language="javascript" />
         </div>
         <div class='flex-none'>
-          <div class="pv2">
+          <div class="pt2">
             <div v-if="output.test && cachedCode" v-bind="output.test">
               <div class="lh-copy pv2 ph3 bg-red white" v-if="output.test.error">
                 Error: {{output.test.error.message}}
@@ -135,7 +134,7 @@
                 </highlight-code>
               </div>
             </div>
-            <div class="lh-copy pv2 ph3" v-else>
+            <div class="pt2 lh-copy" v-else>
               <div v-if="isFileLesson">
                 Upload file(s) and update the code to complete the exercise. Click <strong>Submit</strong> to check your answer.
               </div>
@@ -144,7 +143,7 @@
               </div>
             </div>
           </div>
-          <div class="pt3 ph2 tr">
+          <div class="pt2 tr">
             <div v-if="lessonPassed && (lessonNumber === lessonsInWorkshop)">
               <Button v-bind:click="tutorialMenu" class="bg-aqua white">More Tutorials</Button>
             </div>
@@ -504,7 +503,6 @@ button:disabled {
 span.textLink {
   color: blue;
   cursor: pointer;
-  text-decoration: underline;
 }
 
 footer a {
@@ -527,6 +525,25 @@ div.dropfile input {
 
 div#drop-area * {
   pointer-events: none;
+}
+
+.chevron {
+  width: 7px;
+  height: 7px;
+  margin-right: 5px;
+  border: solid blue;
+  border-width: 0 1px 1px 0;
+  display: inline-block;
+}
+
+.chevron.up {
+  margin-bottom: -1px;
+  transform: rotate(225deg);
+}
+
+.chevron.down {
+  margin-bottom: 3px;
+  transform: rotate(45deg);
 }
 </style>
 


### PR DESCRIPTION
With the lib we're using to render the monaco editor we can't open a new tab nor have a [diff editor](https://microsoft.github.io/monaco-editor/playground.html#creating-the-diffeditor-multi-line-example) (this would be the nicer solution IMO).

I've been looking for other vue monaco lib but haven't found any that supports that.

So, another approach I thought about was to toggle another editor (read only) with the solution:

<img width="773" alt="sol" src="https://user-images.githubusercontent.com/33324750/56900998-064ba880-6a8f-11e9-8935-43b05219934c.png">

## See it in action

![s](https://user-images.githubusercontent.com/33324750/56901011-0b105c80-6a8f-11e9-9d34-6b223b55374b.gif)

There are two problems that can arise: 

- When there's a lot of code in the editor, you'll have to scroll down to view the solution (to overcome this we can automatically scroll to the solution code when pressing the `View Solution` button);
- It may not be clear to the user what gets submitted when you press the `Submit` button;

<hr />

Closes https://github.com/ProtoSchool/protoschool.github.io/issues/211.