### PR TITLE
Fix alt tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Select the appropriate boilerplate Vue file for your lesson from the `tutorials/
 
 Copy that boilerplate into your tutorial folder and rename it to the 2-digit number of the lesson.
 
-Example (while in `tutorials`):
+Example (while in `src/tutorials`):
 
 ```sh
-> cp boilerplate/boilerplate-standard.vue Tutorial-Shortname/01.vue
+> cp boilerplates/boilerplate-standard.vue Tutorial-Shortname/01.vue
 ```
 
 Replace anything in the boilerplate file that reads "REPLACEME".

--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -21,7 +21,7 @@
           <h2 class="mt0 mb2 green fw4 fill-current">
             <span style='vertical-align:-1px'>
               <img v-if="lessonPassed" src="../static/images/complete.svg" alt="complete" style="height: 1rem;"/>
-              <img v-else-if="cachedCode" src="../static/images/in-progress.svg" alt="complete" style="height: 1rem;"/>
+              <img v-else-if="cachedCode" src="../static/images/in-progress.svg" alt="in progress" style="height: 1rem;"/>
               <img v-else src="../static/images/not-started.svg" alt="not yet started" style="height: 1rem;"/>
             </span>
             <span class="green ttu f6 pl2 pr1 fw7 v-mid">

--- a/src/components/LessonLink.vue
+++ b/src/components/LessonLink.vue
@@ -4,7 +4,7 @@
       <div class="green ttu f6" style="min-width: 72px">Lesson {{index}}</div>
       <div class="pr2">
         <img v-if="lessonPassed('passed' + to)" src="../static/images/complete.svg" alt="complete" style="height: 1rem;"/>
-        <img v-else-if="lessonCached('cached' + to)" src="../static/images/in-progress.svg" alt="complete" style="height: 1rem;"/>
+        <img v-else-if="lessonCached('cached' + to)" src="../static/images/in-progress.svg" alt="in progress" style="height: 1rem;"/>
         <img v-else src="../static/images/not-started.svg" alt="not yet started" style="height: 1rem;"/>
       </div>
       <div class="navy fw5 mw6">{{name}}</div>


### PR DESCRIPTION
While testing with a screen reader I discovered that 
- our usage of symbols for complete / in progress / not yet started status in the lesson listings are very cool when read by a screen reader! 
- our "in progress" label had "complete" as its alt tag :(

This PR fixes the alt tags and also fixes some relative path mistakes in the readme.