### PR TITLE
feat: add markdown to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ if (result === 'foo') {
   return { success: 'Happy Message!' }
 } else if (result === 'bar') {
   return {
-    success: 'You did it!',
+    success: 'You did it!', // A string, which can optionally include markdown formatting
     logDesc: 'Check out the current value of `CID`:', // A description of the data you're displaying (a string, which can optionally include markdown formatting)
     log: ipfsFiles // The data you want the user to see (a JSON object or a string)
   }

--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -114,14 +114,12 @@
         <div class='flex-none'>
           <div class="pt2">
             <div v-if="output.test && cachedCode" v-bind="output.test">
-              <div class="lh-copy pv2 ph3 bg-red white" v-if="output.test.error" data-cy="test-error">
+              <div class="lh-copy pv2 ph3 bg-red white" v-if="output.test.error">
                 Error: {{output.test.error.message}}
               </div>
-              <div class="lh-copy pv2 ph3 bg-red white" v-if="output.test.fail" data-cy="test-fail">
-                {{output.test.fail}}
-              </div>
-              <div class="lh-copy pv2 ph3 bg-green white" v-if="output.test.success && lessonPassed" data-cy="test-success">
-                {{output.test.success}}
+              <div class="output-log lh-copy bg-red white" v-if="output.test.fail" v-html="parseData(output.test.fail)" />
+              <div class="lh-copy bg-green white" v-if="output.test.success && lessonPassed">
+                <span class="output-log" v-html="parseData(output.test.success)" />
                 <a v-if="output.test.cid"
                 class="link fw7 underline-hover dib ph2 mh2 white" target='explore-ipld' :href='exploreIpldUrl'>
                   View in IPLD Explorer
@@ -130,8 +128,8 @@
               <div v-if="output.test.log">
                 <div v-if="isFileLesson" class="f5 fw7 mt4 mb2">Step 3: Inspect results</div>
                 <div v-else class="f5 fw7 mt4 mb2">Inspect results</div>
-                <div v-if="output.test.logDesc" class="lh-copy" v-html="parsedLogDesc()"></div>
-                <highlight-code lang="json" class="output-log">
+                <div v-if="output.test.logDesc" class="lh-copy" v-html="parseData(output.test.logDesc)" />
+                <highlight-code lang="json" class="output-code">
                   {{output.test.log}}
                 </highlight-code>
               </div>
@@ -281,7 +279,6 @@ export default {
     }
   },
   computed: {
-
     exploreIpldUrl: function () {
       let cid = this.output.test && this.output.test.cid && this.output.test.cid.toBaseEncodedString()
       cid = cid || ''
@@ -463,11 +460,7 @@ export default {
     toggleExpandExercise: function () {
       this.expandExercise = !this.expandExercise
     },
-    parsedLogDesc: function () {
-      if (this.output && this.output.test && this.output.test.logDesc) {
-        return marked(this.output.test.logDesc)
-      }
-    }
+    parseData: (data) => marked(data)
   }
 }
 </script>
@@ -576,11 +569,16 @@ div#drop-area * {
 </style>
 
 <style> /* We need this unscoped to override the hljs styles. */
-.output-log {
+.output-log p {
+  display: inline-block;
+  margin: .5rem 1rem;
+}
+
+.output-code {
   margin: 1rem 0 0 0;
 }
 
-.output-log code {
+.output-code code {
   margin: 0;
   padding: 1rem;
   background: white;

--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -570,8 +570,13 @@ div#drop-area * {
 
 <style> /* We need this unscoped to override the hljs styles. */
 .output-log p {
+  word-break: break-all;
   display: inline-block;
   margin: .5rem 1rem;
+}
+
+.output-log code {
+  background-color: rgba(0, 0, 0, 0.2);
 }
 
 .output-code {

--- a/src/tutorials/Basics/01.vue
+++ b/src/tutorials/Basics/01.vue
@@ -33,7 +33,7 @@ const validate = async (result, ipfs) => {
     const expected = JSON.stringify({ test: 1 })
     const got = JSON.stringify(obj.value)
 
-    return { fail: `Was expecting "${expected}" but got "${got}"` }
+    return { fail: `Was expecting \`${expected}\` but got \`${got}\`.` }
   }
 }
 

--- a/src/tutorials/Basics/02.vue
+++ b/src/tutorials/Basics/02.vue
@@ -18,16 +18,6 @@ import concepts from './02-concepts.md'
 import exercise from './02-exercise.md'
 import CID from 'cids'
 
-const code = `/* globals ipfs */
-
-const run = async () => {
-  let cid = await ipfs.dag.put({ test: 1 })
-  // your code goes here
-}
-
-return run
-`
-
 const validate = async (result, ipfs) => {
   if (!result) {
     return { fail: 'You forgot to return a result :)' }
@@ -45,9 +35,19 @@ const validate = async (result, ipfs) => {
     const expected = JSON.stringify({ bar: new CID(hash) })
     const got = JSON.stringify(obj.value)
 
-    return { fail: `Was expecting "${expected}" but got "${got}"` }
+    return { fail: `Was expecting \`${expected}\` but got \`${got}\`.` }
   }
 }
+
+const code = `/* globals ipfs */
+
+const run = async () => {
+  let cid = await ipfs.dag.put({ test: 1 })
+  // your code goes here
+}
+
+return run
+`
 
 const solution = `/* globals ipfs */
 

--- a/src/tutorials/Basics/03.vue
+++ b/src/tutorials/Basics/03.vue
@@ -15,6 +15,22 @@ import Lesson from '../../components/Lesson'
 import text from './03.md'
 import exercise from './03-exercise.md'
 
+const validate = async (result, ipfs) => {
+  if (!result) {
+    return { fail: 'You forgot to return a result :)' }
+  }
+
+  if (result === 1) {
+    return { success: 'Great job! You\'ve completed this series of lessons!' }
+  } else if (result.value === 1 && result.remainderPath === '') {
+    return { fail: 'Just want the `value` of `test`, try again.' }
+  } else {
+    const got = JSON.stringify(result)
+
+    return { fail: `Was expecting \`1\` but got \`${got}\`.` }
+  }
+}
+
 const code = `/* globals ipfs */
 
 const run = async () => {
@@ -25,24 +41,6 @@ const run = async () => {
 
 return run
 `
-
-const validate = async (result, ipfs) => {
-  if (!result) {
-    return { fail: 'You forgot to return a result :)' }
-  }
-
-  // TODO: validate ipfs.dag.get call
-
-  if (result === 1) {
-    return { success: `Great job! You've completed this series of lessons!` }
-  } else if (result.value === 1 && result.remainderPath === '') {
-    return { fail: 'Just want the `value` of `test`, try again.' }
-  } else {
-    const got = JSON.stringify(result)
-
-    return { fail: `Was expecting "1" but got "${got}".` }
-  }
-}
 
 const solution = `/* globals ipfs */
 

--- a/src/tutorials/Blog/01.vue
+++ b/src/tutorials/Blog/01.vue
@@ -16,22 +16,6 @@ import utils from './utils.js'
 import shallowEqualArrays from 'shallow-equal/arrays'
 import CID from 'cids'
 
-const code = `/* globals ipfs */
-
-const run = async () => {
-  const natCid = await ipfs.dag.put({ author: "Nat" })
-  const samCid = await ipfs.dag.put({ author: "Sam" })
-
-  // Modify the blog posts below
-  const treePostCid = await ipfs.dag.put({ content: "trees" })
-  const computerPostCid = await ipfs.dag.put({ content: "computers" })
-
-  return [treePostCid, computerPostCid]
-}
-
-return run
-`
-
 const validate = async (result, ipfs) => {
   if (!result) {
     return { fail: 'You forgot to return a result :)' }
@@ -65,7 +49,7 @@ const validate = async (result, ipfs) => {
         break
     }
     if (nodeAuthor.toBaseEncodedString() !== expectedAuthor) {
-      return { fail: `The author of the "${node.content}" blog post (${nodeAuthor}) did not match the the expected author (${expectedAuthor}).` }
+      return { fail: `The author of the \`${node.content}\` blog post (${nodeAuthor}) did not match the the expected author (${expectedAuthor}).` }
     }
   }
   const expectedCids = ['zdpuAkSPEnmgR1rqKkzpFN5qfJshCQKqMaVtUSpQJAMLdw3KF', 'zdpuAxzw762rP3CXZpAsKagPFR2AyqmZU2sN8U1GuVCeoYUEo']
@@ -73,9 +57,25 @@ const validate = async (result, ipfs) => {
   if (shallowEqualArrays(resultCids.sort(), expectedCids.sort())) {
     return { success: 'Everything works!' }
   } else {
-    return { fail: `The returned CIDs ${utils.stringify(resultCids)} did not match the expected CIDs ${utils.stringify(expectedCids)}.` }
+    return { fail: `The returned CIDs \`${utils.stringify(resultCids)}\` did not match the expected CIDs \`${utils.stringify(expectedCids)}\`.` }
   }
 }
+
+const code = `/* globals ipfs */
+
+const run = async () => {
+  const natCid = await ipfs.dag.put({ author: "Nat" })
+  const samCid = await ipfs.dag.put({ author: "Sam" })
+
+  // Modify the blog posts below
+  const treePostCid = await ipfs.dag.put({ content: "trees" })
+  const computerPostCid = await ipfs.dag.put({ content: "computers" })
+
+  return [treePostCid, computerPostCid]
+}
+
+return run
+`
 
 const solution = `/* globals ipfs */
 

--- a/src/tutorials/Blog/02.vue
+++ b/src/tutorials/Blog/02.vue
@@ -15,29 +15,6 @@ import exercise from './02-exercise.md'
 import utils from './utils.js'
 import shallowEqualArrays from 'shallow-equal/arrays'
 
-const code = `/* globals ipfs */
-
-const run = async () => {
-  const natCid = await ipfs.dag.put({ author: "Nat" })
-  const samCid = await ipfs.dag.put({ author: "Sam" })
-
-  // Modify the blog posts below
-  const treePostCid = await ipfs.dag.put({
-    content: "trees",
-    author: samCid
-  })
-  const computerPostCid = await ipfs.dag.put({
-    content: "computers",
-    author: natCid
-  })
-
-  // DELETE ME
-
-  return [treePostCid, computerPostCid]
-}
-
-return run`
-
 const validate = async (result, ipfs) => {
   if (!result) {
     return { fail: 'You forgot to return a result :)' }
@@ -82,7 +59,7 @@ const validate = async (result, ipfs) => {
         break
     }
     if (!shallowEqualArrays(node.tags.sort(), expectedTags.sort())) {
-      return { fail: `The tags of the "${node.content}" blog post ${utils.stringify(node.tags)} did not match the the expected tags ${utils.stringify(expectedTags)}.` }
+      return { fail: `The tags of the \`${node.content}\` blog post \`${utils.stringify(node.tags)}\` did not match the the expected tags \`${utils.stringify(expectedTags)}\`.` }
     }
   }
 
@@ -97,6 +74,30 @@ const validate = async (result, ipfs) => {
     }
   }
 }
+
+const code = `/* globals ipfs */
+
+const run = async () => {
+  const natCid = await ipfs.dag.put({ author: "Nat" })
+  const samCid = await ipfs.dag.put({ author: "Sam" })
+
+  // Modify the blog posts below
+  const treePostCid = await ipfs.dag.put({
+    content: "trees",
+    author: samCid
+  })
+  const computerPostCid = await ipfs.dag.put({
+    content: "computers",
+    author: natCid
+  })
+
+  // DELETE ME
+
+  return [treePostCid, computerPostCid]
+}
+
+return run
+`
 
 const solution = `/* globals ipfs */
 

--- a/src/tutorials/Blog/03.vue
+++ b/src/tutorials/Blog/03.vue
@@ -16,27 +16,6 @@ import utils from './utils.js'
 import shallowEqualArrays from 'shallow-equal/arrays'
 import CID from 'cids'
 
-const code = `/* globals ipfs */
-
-const run = async () => {
-  const natCid = await ipfs.dag.put({ author: "Nat" })
-  const samCid = await ipfs.dag.put({ author: "Sam" })
-  const treePostCid = await ipfs.dag.put({
-    content: "trees",
-    author: samCid,
-    tags: ["outdoor", "hobby"]
-  })
-  const computerPostCid = await ipfs.dag.put({
-    content: "computers",
-    author: natCid,
-    tags: ["hobby"]
-  })
-
-  // Add your code here
-}
-
-return run`
-
 const validate = async (result, ipfs) => {
   if (!result) {
     return { fail: 'You forgot to return a result :)' }
@@ -76,11 +55,11 @@ const validate = async (result, ipfs) => {
         expectedPosts = [treePostCid]
         break
       default:
-        return { fail: `Wrong tag (${node.tag}). Did you mean "hobby" or "outdoor"?` }
+        return { fail: `Wrong tag (${node.tag}). Did you mean \`hobby\` or \`outdoor\`?` }
     }
     const nodePosts = node.posts.map(post => post.toBaseEncodedString())
     if (!shallowEqualArrays(nodePosts.sort(), expectedPosts.sort())) {
-      return { fail: `The posts of the tag "${node.tag}" ${utils.stringify(nodePosts)} did not match the the expected posts ${utils.stringify(expectedPosts)}.` }
+      return { fail: `The posts of the tag \`${node.tag}\` ${utils.stringify(nodePosts)} did not match the the expected posts ${utils.stringify(expectedPosts)}.` }
     }
   }
 
@@ -88,6 +67,28 @@ const validate = async (result, ipfs) => {
   // matter. But that order really doesn't matter.
   return { success: 'Everything works!' }
 }
+
+const code = `/* globals ipfs */
+
+const run = async () => {
+  const natCid = await ipfs.dag.put({ author: "Nat" })
+  const samCid = await ipfs.dag.put({ author: "Sam" })
+  const treePostCid = await ipfs.dag.put({
+    content: "trees",
+    author: samCid,
+    tags: ["outdoor", "hobby"]
+  })
+  const computerPostCid = await ipfs.dag.put({
+    content: "computers",
+    author: natCid,
+    tags: ["hobby"]
+  })
+
+  // Add your code here
+}
+
+return run
+`
 
 const solution = `/* globals ipfs */
 

--- a/src/tutorials/Blog/05.vue
+++ b/src/tutorials/Blog/05.vue
@@ -16,41 +16,6 @@ import utils from './utils.js'
 import shallowEqualArrays from 'shallow-equal/arrays'
 import CID from 'cids'
 
-const code = `/* globals ipfs */
-
-const run = async () => {
-  const natCid = await ipfs.dag.put({ author: "Nat" })
-  const samCid = await ipfs.dag.put({ author: "Sam" })
-  const treePostCid = await ipfs.dag.put({
-    content: "trees",
-    author: samCid,
-    tags: ["outdoor", "hobby"]
-  })
-  const computerPostCid = await ipfs.dag.put({
-    content: "computers",
-    author: natCid,
-    tags: ["hobby"]
-  })
-  const dogPostCid = await ipfs.dag.put({
-    content: "dogs",
-    author: samCid,
-    tags: ["funny", "hobby"]
-  })
-
-  const outdoorTagCid = await ipfs.dag.put({
-    tag: "outdoor",
-    posts: [treePostCid]
-  })
-  const hobbyTagCid = await ipfs.dag.put({
-    tag: "hobby",
-    posts: [treePostCid, computerPostCid]
-  })
-
-  // Add your new code here and modify the tags above
-}
-
-return run`
-
 const validate = async (result, ipfs) => {
   if (!result) {
     return { fail: 'You forgot to return a result :)' }
@@ -100,7 +65,7 @@ const validate = async (result, ipfs) => {
     }
     const nodePosts = node.posts.map(post => post.toBaseEncodedString())
     if (!shallowEqualArrays(nodePosts.sort(), expectedPosts.sort())) {
-      return { fail: `The posts of the tag "${node.tag}" ${utils.stringify(nodePosts)} did not match the the expected posts ${utils.stringify(expectedPosts)}.` }
+      return { fail: `The posts of the tag \`${node.tag}\` ${utils.stringify(nodePosts)} did not match the the expected posts ${utils.stringify(expectedPosts)}.` }
     }
   }
 
@@ -108,6 +73,42 @@ const validate = async (result, ipfs) => {
   // But that order really doesn't matter.
   return { success: 'Everything works!' }
 }
+
+const code = `/* globals ipfs */
+
+const run = async () => {
+  const natCid = await ipfs.dag.put({ author: "Nat" })
+  const samCid = await ipfs.dag.put({ author: "Sam" })
+  const treePostCid = await ipfs.dag.put({
+    content: "trees",
+    author: samCid,
+    tags: ["outdoor", "hobby"]
+  })
+  const computerPostCid = await ipfs.dag.put({
+    content: "computers",
+    author: natCid,
+    tags: ["hobby"]
+  })
+  const dogPostCid = await ipfs.dag.put({
+    content: "dogs",
+    author: samCid,
+    tags: ["funny", "hobby"]
+  })
+
+  const outdoorTagCid = await ipfs.dag.put({
+    tag: "outdoor",
+    posts: [treePostCid]
+  })
+  const hobbyTagCid = await ipfs.dag.put({
+    tag: "hobby",
+    posts: [treePostCid, computerPostCid]
+  })
+
+  // Add your new code here and modify the tags above
+}
+
+return run
+`
 
 const solution = `/* globals ipfs */
 

--- a/src/tutorials/Blog/06.vue
+++ b/src/tutorials/Blog/06.vue
@@ -14,6 +14,76 @@ import text from './06.md'
 import exercise from './06-exercise.md'
 import CID from 'cids'
 
+const validate = async (result, ipfs) => {
+  if (!result) {
+    return { fail: 'You forgot to return a result :)' }
+  }
+  if (!CID.isCID(result)) {
+    return { fail: 'Did not return a valid CID instance.' }
+  }
+  const node = (await ipfs.dag.get(result)).value
+  if (node.content === undefined || node.content !== 'dogs') {
+    return { fail: `The returned value should be the CID of the "dogs" blog post.` }
+  }
+  if (node.prev === undefined) {
+    return { fail: 'The "dogs" blog post needs to have a `prev` field.' }
+  }
+  if (!CID.isCID(node.prev)) {
+    return { fail: 'The value of `prev` of the "dogs" blog post needs to be a link.' }
+  }
+
+  const dogPostCid = 'zdpuAxe3g8XBLrqbp3NrjaiBLTrXjJ3SJymePGutsRRMrhAKS'
+  const computerPostCid = 'zdpuAwwT4kGJxT7mgVZRgvmV3ke8qGNZGLuCgLhJsdBSQGM44'
+  const treePostCid = 'zdpuAri55PR9iW239ahcbnfkFU2TVyD5iLmqEFmwY634KZAJV'
+  const treePostCidPrevNull = 'zdpuAoNUinwYTMoTR8Wq7945MKSSpAUNGW1d1wkTHhRcchG3D'
+  const computerPostCidWhenTreePostCidPrevNull = 'zdpuAsFHXZkpXcjuERjACPp1pAs9J7b4cdYtn9Dv9xBcAGhWV'
+  const dogPostCidWhenTreePostCidPrevNull = 'zdpuAkUysBpAE2yvWdLCBbUqXusYVe5kgFSS7YriyeLfA5F5d'
+  const nodePrev = node.prev
+
+  const computerNode = (await ipfs.dag.get(nodePrev)).value
+  if (computerNode.content === undefined) {
+    return { fail: 'The `dogs` blog post should link to the `computers` blog post.' }
+  }
+  if (computerNode.content !== 'computers') {
+    return { fail: `The \`dogs\` blog post should link to the \`computers\` blog post, but it links to ${computerNode.content}.` }
+  }
+  if (computerNode.prev === undefined) {
+    return { fail: 'The `computers` blog post needs to have a `prev` field.' }
+  }
+  if (!CID.isCID(computerNode.prev)) {
+    return { fail: 'The value of `prev` of the `computers` blog post needs to be a link.' }
+  }
+  const computerNodePrev = computerNode.prev
+
+  const treeNode = (await ipfs.dag.get(computerNodePrev)).value
+  if (treeNode.content === undefined) {
+    return { fail: 'The `computers` blog post should link to the `trees` blog post.' }
+  }
+  if (treeNode.content !== 'trees') {
+    return { fail: `The \`computers\` blog post should link to the \`trees\` blog post, but it links to ${treeNode.content}.` }
+  }
+  if (('prev' in treeNode) && (treeNode.prev !== null)) {
+    return { fail: 'The `trees` blog post shouldn\'t link to other blog posts.' }
+  }
+
+  const computerNodePrevCid = computerNodePrev.toBaseEncodedString()
+  if (![treePostCid, treePostCidPrevNull].includes(computerNodePrevCid)) {
+    return { fail: `The \`computers\` blog post should link to the \`trees\` blog post, but it links to ${computerNodePrevCid}.` }
+  }
+
+  const nodePrevCid = nodePrev.toBaseEncodedString()
+  if (![computerPostCid, computerPostCidWhenTreePostCidPrevNull].includes(nodePrevCid)) {
+    return { fail: `The "dogs" blog post should link to the "computers" blog post, but it links to ${nodePrevCid}.` }
+  }
+
+  const nodeCid = result.toBaseEncodedString()
+  if (nodeCid === dogPostCid || dogPostCidWhenTreePostCidPrevNull) {
+    return { success: 'Everything works!' }
+  } else {
+    return { fail: `The returned CID ${nodeCid} did not match the expected CID ${dogPostCid}.` }
+  }
+}
+
 const code = `/* globals ipfs */
 
 const run = async () => {
@@ -54,77 +124,8 @@ const run = async () => {
   return dogPostCid
 }
 
-return run`
-
-const validate = async (result, ipfs) => {
-  if (!result) {
-    return { fail: 'You forgot to return a result :)' }
-  }
-  if (!CID.isCID(result)) {
-    return { fail: 'Did not return a valid CID instance.' }
-  }
-  const node = (await ipfs.dag.get(result)).value
-  if (node.content === undefined || node.content !== 'dogs') {
-    return { fail: `The returned value should be the CID of the "dogs" blog post.` }
-  }
-  if (node.prev === undefined) {
-    return { fail: 'The "dogs" blog post needs to have a `prev` field.' }
-  }
-  if (!CID.isCID(node.prev)) {
-    return { fail: 'The value of `prev` of the "dogs" blog post needs to be a link.' }
-  }
-
-  const dogPostCid = 'zdpuAxe3g8XBLrqbp3NrjaiBLTrXjJ3SJymePGutsRRMrhAKS'
-  const computerPostCid = 'zdpuAwwT4kGJxT7mgVZRgvmV3ke8qGNZGLuCgLhJsdBSQGM44'
-  const treePostCid = 'zdpuAri55PR9iW239ahcbnfkFU2TVyD5iLmqEFmwY634KZAJV'
-  const treePostCidPrevNull = 'zdpuAoNUinwYTMoTR8Wq7945MKSSpAUNGW1d1wkTHhRcchG3D'
-  const computerPostCidWhenTreePostCidPrevNull = 'zdpuAsFHXZkpXcjuERjACPp1pAs9J7b4cdYtn9Dv9xBcAGhWV'
-  const dogPostCidWhenTreePostCidPrevNull = 'zdpuAkUysBpAE2yvWdLCBbUqXusYVe5kgFSS7YriyeLfA5F5d'
-  const nodePrev = node.prev
-
-  const computerNode = (await ipfs.dag.get(nodePrev)).value
-  if (computerNode.content === undefined) {
-    return { fail: `The "dogs" blog post should link to the "computers" blog post.` }
-  }
-  if (computerNode.content !== 'computers') {
-    return { fail: `The "dogs" blog post should link to the "computers" blog post, but it links to ${computerNode.content}.` }
-  }
-  if (computerNode.prev === undefined) {
-    return { fail: 'The "computers" blog post needs to have a `prev` field.' }
-  }
-  if (!CID.isCID(computerNode.prev)) {
-    return { fail: 'The value of `prev` of the "computers" blog post needs to be a link.' }
-  }
-  const computerNodePrev = computerNode.prev
-
-  const treeNode = (await ipfs.dag.get(computerNodePrev)).value
-  if (treeNode.content === undefined) {
-    return { fail: `The "computers" blog post should link to the "trees" blog post.` }
-  }
-  if (treeNode.content !== 'trees') {
-    return { fail: `The "computers" blog post should link to the "trees" blog post, but it links to ${treeNode.content}.` }
-  }
-  if (('prev' in treeNode) && (treeNode.prev !== null)) {
-    return { fail: 'The "trees" blog post shouldn\'t link to other blog posts.' }
-  }
-
-  const computerNodePrevCid = computerNodePrev.toBaseEncodedString()
-  if (![treePostCid, treePostCidPrevNull].includes(computerNodePrevCid)) {
-    return { fail: `The "computers" blog post should link to the "trees" blog post, but it links to ${computerNodePrevCid}.` }
-  }
-
-  const nodePrevCid = nodePrev.toBaseEncodedString()
-  if (![computerPostCid, computerPostCidWhenTreePostCidPrevNull].includes(nodePrevCid)) {
-    return { fail: `The "dogs" blog post should link to the "computers" blog post, but it links to ${nodePrevCid}.` }
-  }
-
-  const nodeCid = result.toBaseEncodedString()
-  if (nodeCid === dogPostCid || dogPostCidWhenTreePostCidPrevNull) {
-    return { success: 'Everything works!' }
-  } else {
-    return { fail: `The returned CID ${nodeCid} did not match the expected CID ${dogPostCid}.` }
-  }
-}
+return run
+`
 
 const solution = `/* globals ipfs */
 

--- a/src/tutorials/Blog/07.vue
+++ b/src/tutorials/Blog/07.vue
@@ -17,6 +17,56 @@ import exercise from './07-exercise.md'
 import shallowEqualArrays from 'shallow-equal/arrays'
 import CID from 'cids'
 
+const validate = async (result, ipfs) => {
+  if (!result) {
+    return { fail: 'No result was returned. Did you forget to return a result from your `traversePosts` function? Or perhaps you accidentally edited the `run` function?' }
+  }
+
+  if (result.error && result.error.message === `Cannot read property 'prev' of undefined`) {
+    return { fail: 'Cannot read property `prev` of undefined. Did you try to access the value of `ipfs.dag.get()` before the function completed?' }
+  }
+
+  if (result.error && result.error.message === `Cannot read property 'value' of undefined`) {
+    return { fail: 'Cannot read property `value` of undefined. Did you try to access the value of `ipfs.dag.get()` before the function completed?' }
+  }
+
+  if (result.error) {
+    return { error: result.error }
+  }
+
+  if (!Array.isArray(result)) {
+    return { fail: 'The return value of your traversePosts function needs to be an array.' }
+  }
+
+  const dogPostCid = 'zdpuAxe3g8XBLrqbp3NrjaiBLTrXjJ3SJymePGutsRRMrhAKS'
+  const computerPostCid = 'zdpuAwwT4kGJxT7mgVZRgvmV3ke8qGNZGLuCgLhJsdBSQGM44'
+  const treePostCid = 'zdpuAri55PR9iW239ahcbnfkFU2TVyD5iLmqEFmwY634KZAJV'
+
+  try {
+    if (result.length !== 3 || result === undefined) {
+      return { fail: 'Your traversePosts function needs to return 3 CIDs' }
+    }
+    const isCids = result.every(CID.isCID)
+    if (!isCids) {
+      return { fail: 'Your traversePosts function needs to return CIDs.' }
+    }
+    const expectedCids = [treePostCid, computerPostCid, dogPostCid]
+    const returnedCids = result.map(item => item.toBaseEncodedString())
+    if (!shallowEqualArrays(returnedCids.sort(), expectedCids.sort())) {
+      return {
+        fail: 'The CIDs returned by the traversePosts function did not match the expected CIDs.',
+        log: {
+          returnedCids: returnedCids,
+          expectedCids: expectedCids
+        }
+      }
+    }
+  } catch (err) {
+    return { fail: `Your function threw an error: ${err}.` }
+  }
+  return { success: 'Great job! You\'ve completed this series of lessons!' }
+}
+
 const code = `/* globals ipfs */
 
 const traversePosts = async (cid) => {
@@ -61,57 +111,8 @@ const run = async () => {
   return traversePosts(dogPostCid)
 }
 
-return run`
-
-const validate = async (result, ipfs) => {
-  if (!result) {
-    return { fail: 'No result was returned. Did you forget to return a result from your traversePosts function? Or perhaps you accidentally edited the run function?' }
-  }
-
-  if (result.error && result.error.message === `Cannot read property 'prev' of undefined`) {
-    return { fail: `Cannot read property 'prev' of undefined. Did you try to access the value of ipfs.dag.get() before the function completed?` }
-  }
-
-  if (result.error && result.error.message === `Cannot read property 'value' of undefined`) {
-    return { fail: `Cannot read property 'value' of undefined. Did you try to access the value of ipfs.dag.get() before the function completed?` }
-  }
-
-  if (result.error) {
-    return { error: result.error }
-  }
-
-  if (!Array.isArray(result)) {
-    return { fail: 'The return value of your traversePosts function needs to be an array.' }
-  }
-
-  const dogPostCid = 'zdpuAxe3g8XBLrqbp3NrjaiBLTrXjJ3SJymePGutsRRMrhAKS'
-  const computerPostCid = 'zdpuAwwT4kGJxT7mgVZRgvmV3ke8qGNZGLuCgLhJsdBSQGM44'
-  const treePostCid = 'zdpuAri55PR9iW239ahcbnfkFU2TVyD5iLmqEFmwY634KZAJV'
-
-  try {
-    if (result.length !== 3 || result === undefined) {
-      return { fail: 'Your traversePosts function needs to return 3 CIDs' }
-    }
-    const isCids = result.every(CID.isCID)
-    if (!isCids) {
-      return { fail: 'Your traversePosts function needs to return CIDs.' }
-    }
-    const expectedCids = [treePostCid, computerPostCid, dogPostCid]
-    const returnedCids = result.map(item => item.toBaseEncodedString())
-    if (!shallowEqualArrays(returnedCids.sort(), expectedCids.sort())) {
-      return {
-        fail: 'The CIDs returned by the traversePosts function did not match the expected CIDs.',
-        log: {
-          returnedCids: returnedCids,
-          expectedCids: expectedCids
-        }
-      }
-    }
-  } catch (err) {
-    return { fail: `Your function threw an error: ${err}.` }
-  }
-  return { success: 'Great job! You\'ve completed this series of lessons!' }
-}
+return run
+`
 
 const solution = `/* globals ipfs */
 


### PR DESCRIPTION
Add markdown support for both the success and fail messages, so you can do whatever:

| old | crazy stuff you can do now |
| --- | --- |
| <img width="720" alt="a" src="https://user-images.githubusercontent.com/33324750/57522177-e7180b00-7319-11e9-9dee-84b97f669f40.png"> | <img width="721" alt="c" src="https://user-images.githubusercontent.com/33324750/57522712-d7e58d00-731a-11e9-8f08-7a6dd0b23688.png"> |


