### PR TITLE
Add analytics w/ page views via Countly 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -53,27 +53,39 @@
         }
         return dntStatus === 'Enabled'
       }
-      /* From https://github.com/nodejs/nodejs.org/blob/703bacbc0da63fa91f156468209758c66c01f30f/layouts/partials/footer.hbs */
+
+      //some default pre init
+      var Countly = Countly || {};
+      Countly.q = Countly.q || [];
+
       (function(){
+
+        // ************ FOR TESTING ONLY ************************
+        // Uncomment line below for testing, comment out for deployment
+        // if (!_dntEnabled()) {
+        // *******************************************************
+
+        // *********** FOR DEPLOYMENT *****************************
+        // Comment out line below for testing, uncomment for deployment
         if (!_dntEnabled() && location.hostname === 'proto.school') {
-          !function(n,o,d,e,j,s){n.GoogleAnalyticsObject=d;n[d]||(n[d]=function(){
-          (n[d].q=n[d].q||[]).push(arguments)});n[d].l=+new Date;j=o.createElement(e);
-          s=o.getElementsByTagName(e)[0];j.async=1;j.src='//www.google-analytics.com/analytics.js';
-          s.parentNode.insertBefore(j,s)}(window,document,'ga','script');
-          if (!ga) return;
-          ga('create', 'UA-96910779-4', 'auto');
-          ga('send', 'pageview');
-          document.documentElement.addEventListener('click', function(e) {
-            // Track case studies
-            if(!e.target || !e.target.dataset || !e.target.dataset.casestudy) return;
-            ga('send', 'event', {
-              eventCategory: 'casestudy',
-              eventAction: 'click',
-              eventLabel: e.target.dataset.casestudy,
-              eventValue: 0
-            });
-          });
-        }
+        // *******************************************************
+
+          //provide countly initialization parameters
+          Countly.app_key = 'c785b6eaa9c61617e1a7db83cb437e5f3dfe4280';
+          Countly.url = 'https://countly.ipfs.io';
+
+          Countly.q.push(['track_sessions']);
+          Countly.q.push(['track_pageview']);
+          Countly.q.push(['track_clicks']);
+
+          //load countly script asynchronously
+           var cly = document.createElement('script'); cly.type = 'text/javascript';
+           cly.async = true;
+           //enter url of script here
+           cly.src = 'https://countly.ipfs.io/sdk/web/countly.min.js';
+           cly.onload = function(){Countly.init()};
+           var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(cly, s);
+         }
       })();
     </script>
   </body>

--- a/src/main.js
+++ b/src/main.js
@@ -101,6 +101,10 @@ const router = new VueRouter({
   }
 })
 
+router.afterEach((to, from, next) => {
+  console.log("to", to.path)
+})
+
 Vue.config.productionTip = false
 
 new Vue({

--- a/src/main.js
+++ b/src/main.js
@@ -101,8 +101,10 @@ const router = new VueRouter({
   }
 })
 
-router.afterEach((to, from, next) => {
-  console.log("to", to.path)
+// track page view via Countly when route changes
+router.afterEach((to) => {
+  if (!window.Countly) return
+  window.Countly.q.push(['track_pageview', to.path])
 })
 
 Vue.config.productionTip = false


### PR DESCRIPTION
This PR adds tracking via Countly (hosted at countly.ipfs.io) while respecting "do not track" requests in the user agent. 

It taps into Vue's routing system to allow us to see the path for any resource that has its own path, such as tutorial landing pages and individual lessons: 
![image](https://user-images.githubusercontent.com/19171465/60992805-3dee9080-a31b-11e9-95ad-7d7a7aefea2e.png)

This PR also removes tracking via Google Analytics. (Will this cause any problems for you, @mikeal?)

This PR does not address event tracking, such as clicks on "reset code," "view solution," or "submit" buttons within lessons. We'll plan to address that in a second PR once this is in place. 

Note: If testing on localhost, you'll need to comment out line 70 in `index.html` (which restricts tracking to views of the live website) and uncomment line 65 (which tracks views on localhost as well).

Pair programmed by @olizilla & @terichadbourne  