### PR TITLE
fix: full height page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,20 +11,35 @@ export default {
 </script>
 
 <style>
+
+html, body {
+  height: 100%;
+}
+
 #app {
+  width: 100%;
+  height: 100%;
   font-family: 'Avenir', Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: #2c3e50;
-  width: 100%;
 }
+
+#app > div {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 pre {
   overflow: auto;
 }
+
 .focus-outline:focus {
   outline: 0;
   box-shadow: 0 0 0 .2rem rgba(201, 210, 215, .4);
 }
+
 .code, code {
   border-radius: 3px;
   background-color: rgba(27,31,35,0.05);
@@ -33,12 +48,14 @@ pre {
   font-size: 85%;
   font-family: SFMono-Regular, Monaco, Consolas, "Liberation Mono", "Courier New", monospace
 }
+
 pre code {
   margin: 0.5rem 0;
   padding: 0.6rem 0.8rem;
   display: block;
   font-size: 12px;
 }
+
 .fill-current {
   fill: currentColor;
 }

--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <Header/>
-    <div class="center mw7 ph2">
+    <div class="container center mw7 ph2">
       <div class="flex-l items-start center mw7 ph2">
         <section class="pv3 mt3" :class="isResources && 'w-100'">
           <div class="lh-solid v-mid f4">
@@ -178,8 +178,8 @@
         </div>
       </section>
     </div>
-    <footer class="bg-navy white ph2 ph3-ns mt4 flex items-center justify-around">
-      <div class="mw7">
+    <footer class="bg-navy white ph2 ph3-ns mt4">
+      <div class="mw7 center">
         <p>Feeling stuck? We'd love to hear what's confusing so we can improve
         this lesson. Please <a :href="issueUrl" target="_blank">share your questions and feedback</a>.</p>
       </div>
@@ -501,6 +501,10 @@ export default {
 </script>
 
 <style scoped>
+.container {
+  flex-grow: 1;
+}
+
 button:disabled {
   cursor: not-allowed;
 }


### PR DESCRIPTION
Make the page full height when there is no content.

Deleted some stuff for this screenshot just to prove that it works:
 
<img width="1071" alt="100vh" src="https://user-images.githubusercontent.com/33324750/61055008-80ca6a00-a3e8-11e9-908f-b173522af33a.png">

Fixes https://github.com/ProtoSchool/protoschool.github.io/issues/255.