### PR TITLE
Fix: allow casing override

### DIFF
--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -1,11 +1,20 @@
 import tutorials from '../static/tutorials.json'
 
-export const deriveShortname = (path) =>
-  path
-    .split('/')[1]
-    .split('-')
-    .map(e => e.charAt(0).toUpperCase() + e.slice(1))
-    .join(' ')
+const correctedCases = {
+  api: 'API'
+}
+
+const fixCasing = function (e) {
+  if (correctedCases.hasOwnProperty(e)) {
+    return correctedCases[e]
+  } else {
+    return e.charAt(0).toUpperCase() + e.slice(1)
+  }
+}
+
+export const deriveShortname = function (path) {
+  return path.split('/')[1].split('-').map(e => fixCasing(e)).join(' ')
+}
 
 export const migrateCache = (tutorialId, pastUrl) => {
   const tutorial = tutorials[tutorialId]

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -1,19 +1,20 @@
 import tutorials from '../static/tutorials.json'
 
+// SET CASING OVERRIDES HERE
+// If a word in a URL would not be appopriate if only the first letter were capitalized,
+// add that word here as a property with the correct capitalization (string) as its value.
+// This is to be used for single words, not full hyphenated paths. Capitalization of that
+// word will apply throughout all tutorial shortnames that include it.
 const correctedCases = {
   api: 'API'
 }
 
-const fixCasing = function (e) {
-  if (correctedCases.hasOwnProperty(e)) {
-    return correctedCases[e]
-  } else {
-    return e.charAt(0).toUpperCase() + e.slice(1)
-  }
+const fixCasing = function (word) {
+  return correctedCases.hasOwnProperty(word) ? correctedCases[word] : (word.charAt(0).toUpperCase() + word.slice(1))
 }
 
 export const deriveShortname = function (path) {
-  return path.split('/')[1].split('-').map(e => fixCasing(e)).join(' ')
+  return path.split('/')[1].split('-').map(word => fixCasing(word)).join(' ')
 }
 
 export const migrateCache = (tutorialId, pastUrl) => {


### PR DESCRIPTION
Currently the path is used to derive the shortname of a tutorial by splitting it apart into words and capitalizing the first letter of each of them, so for example 

`https://proto.school/#/data-structures` => `Data Structures`

I noticed while proofing the upcoming Files API tutorial that it's printing as `Files Api`, which is less impressive.  This small tweak will allow case-by-case override when we encounter a word that our default casing won't work on. The tweak for `api` => `API` is included in this PR, but to test this PR against the `code` branch you'll need to temporarily adjust the `correctedCases` object in `src/utils/paths.js` to include an example you can already view, for example:  

```javascript
const correctedCases = {
  api: 'API',
  structures: 'STruCTures',
  mutable: 'MUTable'
}
```
I haven't added this step to the instructions because (a) it shouldn't come up much and (b) I'm envisioning it being something we as admins deal with when accepting a PR (in the same way we'll need to decide which tutorials get featured). 