### PR TITLE
Add link to CID inspector when result is CID

### DIFF
--- a/src/components/Output.vue
+++ b/src/components/Output.vue
@@ -46,7 +46,7 @@ export default {
     inspectCidUrl: function () {
       let cid = this.output.test && this.output.test.cid && this.output.test.cid.toBaseEncodedString()
       cid = cid || ''
-      return `https://cid.ipfs.io/#/${cid}`
+      return `https://cid.ipfs.io/#${cid}`
     }
   }
 }

--- a/src/components/Output.vue
+++ b/src/components/Output.vue
@@ -9,11 +9,16 @@
       v-html="parseData(output.test.fail)" />
     <div class="lh-copy bg-green white" v-if="output.test.success && lessonPassed">
       <span class="output-log" v-html="parseData(output.test.success)" />
-      <a
-        v-if="output.test.cid"
-        class="link fw7 underline-hover dib ph2 mh2 white"
-        target="explore-ipld"
+      <span v-if="output.test.cid">
+        <a
+          class="link fw7 underline-hover dib ph2 mh2 white"
+          target="_blank"
         :href="exploreIpldUrl">View in IPLD Explorer</a>
+        <a
+          class="link fw7 underline-hover dib ph2 mh2 white"
+          target="_blank"
+          :href="inspectCidUrl">View in CID Inspector</a>
+      </span>
     </div>
     <div v-if="output.test.log">
       <div v-if="isFileLesson" class="f5 fw7 mt4 mb2">Step 3: Inspect results</div>
@@ -37,6 +42,11 @@ export default {
       let cid = this.output.test && this.output.test.cid && this.output.test.cid.toBaseEncodedString()
       cid = cid || ''
       return `https://explore.ipld.io/#/explore/${cid}`
+    },
+    inspectCidUrl: function () {
+      let cid = this.output.test && this.output.test.cid && this.output.test.cid.toBaseEncodedString()
+      cid = cid || ''
+      return `https://cid.ipfs.io/#/${cid}`
     }
   }
 }


### PR DESCRIPTION
Closes #299 

Partially addresses some of the suggestions for use of IPFS Camp content identified in #261, partially addressing epic #307.

When the result of a code challenge is a CID, a link to "View in CID Inspector" (which goes to a pre-filled URL in https://cid.ipfs.io/) now appears alongside the link to "View in IPLD Explorer."

I'd love feedback on the ideal layout since both options would always be present at the same time. Current state of wrapping shown below, although few people will be attempting to code on narrower screens.
![image](https://user-images.githubusercontent.com/19171465/68806134-3aee0e80-0633-11ea-8d23-837b0d307251.png)
![image](https://user-images.githubusercontent.com/19171465/68806218-68d35300-0633-11ea-85df-cf5e0f7e8c91.png)
![image](https://user-images.githubusercontent.com/19171465/68806248-7ee11380-0633-11ea-95e6-9cbb72e7a048.png)



