### PR TITLE
Update resources pages with IPFS Camp Core Course A

### DIFF
--- a/src/static/tutorials.json
+++ b/src/static/tutorials.json
@@ -13,17 +13,11 @@
 		],
 	  "resources": [
 			{
-				"title": "IPFS: Mutable File System (MFS)",
-				"link": "https://proto.school/#/mutable-file-system",
-				"type": "tutorial",
-				"description": "Explore the Mutable File System (MFS), which lets you work with files and directories in IPFS as if you were using a traditional name-based file system."
-			},
- 			{
-				"title": "P2P Data Links with Content Addressing",
-				"link": "https://proto.school/#/basics/",
-				"type": "tutorial",
-				"description": "Use the IPFS DAG API to create create verifiable links between dataset with Content Identifiers (CIDs)."
-			},
+				 "title": "Understanding How IPFS Deals with Files",
+				 "link": "https://youtu.be/Z5zNPwMDYGg",
+				 "type": "video",
+				 "description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports."
+			 },
 			{
 				"title": "Decentralized Web Primer: The Power of Content-Addressing",
 				"link": "https://flyingzumwalt.gitbooks.io/decentralized-web-primer/content/avenues-for-access/lessons/power-of-content-addressing.html",
@@ -52,6 +46,18 @@
 				"link": "https://ipfs.io/ipfs/QmNhFJjGcMPqpuYfxL62VVB9528NXqDNMFXiqN5bgFYiZ1/its-time-for-the-permanent-web.html",
 				"type": "article",
 				"description": "Kyle Drake of Neocities explores the downsides of the Hypertext Transfer Protocol (HTTP)."
+			},
+			{
+				"title": "IPFS: Mutable File System (MFS)",
+				"link": "https://proto.school/#/mutable-file-system",
+				"type": "tutorial",
+				"description": "Explore the Mutable File System (MFS), which lets you work with files and directories in IPFS as if you were using a traditional name-based file system. (This tutorial includes JavaScript code challenges.)"
+			},
+			{
+				"title": "P2P Data Links with Content Addressing",
+				"link": "https://proto.school/#/basics/",
+				"type": "tutorial",
+				"description": "Use the IPFS DAG API to create create verifiable links between dataset with Content Identifiers (CIDs). (This tutorial includes JavaScript code challenges.)"
 			}
 		]
 	},
@@ -74,7 +80,19 @@
 				"link": "https://proto.school/#/blog/",
 				"type": "tutorial",
 				"description": "Ready for a bigger challenge with the IPFS DAG API? Use CIDs to build and update a complex web of data."
-			}
+			},
+			{
+				 "title": "Understanding How IPFS Deals with Files",
+				 "link": "https://youtu.be/Z5zNPwMDYGg",
+				 "type": "video",
+				 "description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports."
+			 },
+			 {
+				 "title": "IPFS: Regular Files API",
+				 "link": "https://proto.school/#/regular-files-api",
+				 "type": "tutorial",
+				 "description": "Ready to deal with more than primitives? Explore the API custom-built for efficient handling of files in IPFS."
+			 }
 	  ]
 	},
 	"0003": {
@@ -95,7 +113,19 @@
 	    { "title": "JS-IPFS DAG API",
 				"link": "https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/DAG.md",
 				"type": "docs"
-			}
+			},
+			{
+				 "title": "Understanding How IPFS Deals with Files",
+				 "link": "https://youtu.be/Z5zNPwMDYGg",
+				 "type": "video",
+				 "description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports."
+			 },
+			 {
+				 "title": "IPFS: Regular Files API",
+				 "link": "https://proto.school/#/regular-files-api",
+				 "type": "tutorial",
+				 "description": "Ready to deal with more than primitives? Explore the API custom-built for efficient handling of files in IPFS."
+			 }
 	  ]
 	},
 	"0004": {
@@ -117,12 +147,24 @@
 			"Remove a file or directory"
 		],
 	  "resources": [
-	    {
+			{
 				"title": "JS-IPFS Files API",
 				"link": "https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/FILES.md",
 				"type": "docs",
 				"description": "Notice that these docs contain two sections, one for top-level methods relevant to files and one for the Mutable File System (MFS) you learned about in this tutorial."
 			},
+			{
+				 "title": "Understanding How IPFS Deals with Files",
+				 "link": "https://youtu.be/Z5zNPwMDYGg",
+				 "type": "video",
+				 "description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports. It also introduces some the joys and pitfalls of the Mutable File System (MFS)."
+			 },
+			 {
+				 "title": "IPFS: Regular Files API",
+				 "link": "https://proto.school/#/regular-files-api",
+				 "type": "tutorial",
+				 "description": "Explore the other half of the IPFS Files API, where you'll add and retrieve files and read their contents without the abstraction layer of the Mutable File System."
+			 },
 			{
 				"title": "Browser MFS Demo",
 				"link": "https://github.com/ipfs/js-ipfs/tree/master/examples/browser-mfs",
@@ -161,17 +203,18 @@
 		],
 		"resources": [
 			{
+				 "title": "JS-IPFS Files API",
+				 "link": "https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/FILES.md",
+				 "type": "docs",
+				 "description": "Notice that these docs contain two sections, one for top-level methods relevant to files, which we learned about in this tutorial, and one for the Mutable File System (MFS)."
+			 },
+			 {
 				 "title": "Understanding How IPFS Deals with Files",
 				 "link": "https://youtu.be/Z5zNPwMDYGg",
 				 "type": "video",
 				 "description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports. It also introduces some the joys and pitfalls of the Mutable File System (MFS)."
 			 },
-		   {
-					"title": "JS-IPFS Files API",
-					"link": "https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/FILES.md",
-					"type": "docs",
-					"description": "Notice that these docs contain two sections, one for top-level methods relevant to files, which we learned about in this tutorial, and one for the Mutable File System (MFS)."
-				},
+
 				{
 					"title": "IPFS: Mutable File System (MFS)",
 					"link": "https://proto.school/#/mutable-file-system",


### PR DESCRIPTION
- Add video from core course A to multiple resources pages
- Push docs to the top of each resources list
- Add some additional cross-linking between existing tutorials

Partially addresses some of the suggestions for use of IPFS Camp content identified in #261, partially addressing epic #307.