### PR TITLE
Add rendering tests

### DIFF
--- a/cypress/integration/tutorials.spec.js
+++ b/cypress/integration/tutorials.spec.js
@@ -2,12 +2,26 @@
 
 import tutorials from '../../src/static/tutorials.json'
 
+describe('show 0001', function () {
+  renderAllLessonsInTutorial('0001')
+})
+
 describe('📝 0002', function () {
+  renderAllLessonsInTutorial('0002')
   viewSolutionsAndSubmitAll({ tutorialId: '0002', lessonCount: 3 })
 })
 
 describe('📝 0003', function () {
+  renderAllLessonsInTutorial('0003')
   viewSolutionsAndSubmitAll({ tutorialId: '0003', lessonCount: 7 })
+})
+
+describe('show 0004', function () {
+  renderAllLessonsInTutorial('0004')
+})
+
+describe('show 0005', function () {
+  renderAllLessonsInTutorial('0005')
 })
 
 function viewSolutionsAndSubmitAll ({ tutorialId, lessonCount, hasResources = true }) {
@@ -33,4 +47,31 @@ function viewSolutionsAndSubmitAll ({ tutorialId, lessonCount, hasResources = tr
       }
     })
   }
+}
+
+function renderAllLessonsInTutorial (tutorialId) {
+  const tutorialName = tutorials[tutorialId].url
+  const standardLessons = tutorials[tutorialId].lessons
+  const standardLessonCount = standardLessons.length
+
+  console.log('standardLessonCount is ', standardLessonCount)
+  it(`should find the ${tutorialName} tutorial landing page with correct number of lesson links`, function () {
+    cy.visit(`/#/${tutorialName}/`)
+    cy.get(`[data-cy=lesson-link]`).should('have.length', standardLessonCount)
+  })
+  it(`should render all standard lesson pages for ${tutorialName}`, function () {
+    console.log('standardLessons: ', standardLessons)
+    standardLessons.forEach((lessonName, index) => {
+      console.log(lessonName)
+      console.log(index)
+      cy.get(`[data-cy=lesson-link]`).contains(lessonName).click()
+      cy.contains('h1', lessonName)
+      cy.get(`[data-cy=tutorial-landing-link]`).click()
+    })
+  })
+  it(`should find and render a resources page for ${tutorialName}`, function () {
+    cy.get(`[data-cy=lesson-link-resources]`).click()
+    cy.contains('h1', 'Resources')
+    cy.get(`[data-cy=tutorial-landing-link]`).click()
+  })
 }

--- a/cypress/integration/tutorials.spec.js
+++ b/cypress/integration/tutorials.spec.js
@@ -2,7 +2,7 @@
 
 import tutorials from '../../src/static/tutorials.json'
 
-// tutorials with standard coding challenges only (no file upload or multiple choice)
+// tutorials with standard coding challenges only (no file upload, multiple choice, or text only lessons)
 // NEED TO UPDATE WHEN ADDING NEW CONTENT
 const standardCodingTutorials = ['0002', '0003']
 

--- a/cypress/integration/tutorials.spec.js
+++ b/cypress/integration/tutorials.spec.js
@@ -2,26 +2,24 @@
 
 import tutorials from '../../src/static/tutorials.json'
 
-describe('show 0001', function () {
-  renderAllLessonsInTutorial('0001')
+// ensure every lesson in every tutorial included in tutorials.json is renderable, including resources pages
+describe(`RENDER ALL LESSONS/TUTORIALS`, function () {
+  Object.keys(tutorials).forEach(function (tutorial) {
+    describe(`render ${tutorial}`, function () {
+      renderAllLessonsInTutorial(tutorial)
+    })
+  })
 })
 
-describe('📝 0002', function () {
-  renderAllLessonsInTutorial('0002')
-  viewSolutionsAndSubmitAll({ tutorialId: '0002', lessonCount: 3 })
-})
+// for tutorials with standard code challenges, ensure solution code passes lessons
+describe(`PASS STANDARD CODE CHALLENGES`, function () {
+  describe('📝 0002', function () {
+    viewSolutionsAndSubmitAll({ tutorialId: '0002', lessonCount: 3 })
+  })
 
-describe('📝 0003', function () {
-  renderAllLessonsInTutorial('0003')
-  viewSolutionsAndSubmitAll({ tutorialId: '0003', lessonCount: 7 })
-})
-
-describe('show 0004', function () {
-  renderAllLessonsInTutorial('0004')
-})
-
-describe('show 0005', function () {
-  renderAllLessonsInTutorial('0005')
+  describe('📝 0003', function () {
+    viewSolutionsAndSubmitAll({ tutorialId: '0003', lessonCount: 7 })
+  })
 })
 
 function viewSolutionsAndSubmitAll ({ tutorialId, lessonCount, hasResources = true }) {
@@ -54,12 +52,12 @@ function renderAllLessonsInTutorial (tutorialId) {
   const standardLessons = tutorials[tutorialId].lessons
   const standardLessonCount = standardLessons.length
 
-  console.log('standardLessonCount is ', standardLessonCount)
-  it(`should find the ${tutorialName} tutorial landing page with correct number of lesson links`, function () {
+  it(`should find ${tutorialName} landing page with correct lesson count`, function () {
     cy.visit(`/#/${tutorialName}/`)
     cy.get(`[data-cy=lesson-link]`).should('have.length', standardLessonCount)
   })
-  it(`should render all standard lesson pages for ${tutorialName}`, function () {
+
+  it(`should find and render all standard lesson pages in ${tutorialName}`, function () {
     console.log('standardLessons: ', standardLessons)
     standardLessons.forEach((lessonName, index) => {
       console.log(lessonName)
@@ -69,7 +67,8 @@ function renderAllLessonsInTutorial (tutorialId) {
       cy.get(`[data-cy=tutorial-landing-link]`).click()
     })
   })
-  it(`should find and render a resources page for ${tutorialName}`, function () {
+
+  it(`should find and render resources page for ${tutorialName}`, function () {
     cy.get(`[data-cy=lesson-link-resources]`).click()
     cy.contains('h1', 'Resources')
     cy.get(`[data-cy=tutorial-landing-link]`).click()

--- a/cypress/integration/tutorials.spec.js
+++ b/cypress/integration/tutorials.spec.js
@@ -17,7 +17,7 @@ describe(`RENDER ALL LESSONS/TUTORIALS`, function () {
 
 // for tutorials with standard code challenges, ensure solution code passes lessons
 describe(`PASS STANDARD CODE CHALLENGES`, function () {
-  standardCodingTutorials.forEach( tutorialId => {
+  standardCodingTutorials.forEach(tutorialId => {
     describe(`pass ${tutorialId}`, function () {
       viewSolutionsAndSubmitAll(tutorialId)
     })
@@ -42,12 +42,12 @@ function viewSolutionsAndSubmitAll (tutorialId) {
       cy.get('[data-cy=solution-editor-ready]').should('be.visible') // wait for editor to be updated
       cy.get('[data-cy=replace-with-solution]').click({ force: true })
       cy.get('[data-cy=submit-answer]').click()
-      cy.get('[data-cy=next-lesson]').click()  //leads to resources on last iteration
+      cy.get('[data-cy=next-lesson]').click() // leads to resources on last iteration
     })
   }
   it(`should find resources and navigate to tutorials`, function () {
     cy.contains('h1', 'Resources') // loads resources page
-    cy.contains('[data-cy=resources-content]') // loads meaningful content
+    cy.get('[data-cy=resources-content]') // loads meaningful content
     cy.get('[data-cy=more-tutorials]').click()
     cy.url().should('include', `#/tutorials/`)
   })

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -7,7 +7,7 @@
         <div v-if="isLesson && notFound !== true" class="flex overflow-auto items-center bg-aqua navy f5 fw6 pv3 center tc mw7">
           <router-link class="nav-link navy" to="/tutorials">Tutorials</router-link>
           <span class="fw4">></span>
-          <router-link class="nav-link navy" :to="tutorialLanding">{{tutorialShortname}}</router-link>
+          <router-link data-cy="tutorial-landing-link" class="nav-link navy" :to="tutorialLanding">{{tutorialShortname}}</router-link>
         </div>
         <!-- standard nav  -->
         <div v-else class="dn flex overflow-auto items-center bg-aqua white pv3 center tc mw7">

--- a/src/components/Resources.vue
+++ b/src/components/Resources.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="lesson-text lh-copy">
+  <div data-cy="resources-content" class="lesson-text lh-copy">
     <p>Ready to learn more? There are plenty of additional resources to explore, both in ProtoSchool and beyond. <span v-if="data.length > 1">Here are some of our favorites:</span> <span v-else>Here's our top pick:</span></p>
     <div v-for="(item, idx) in data" :key="`resources-${idx}`" class="mb3">
       <p class="ma0 flex items-center">

--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -23,12 +23,13 @@
           <template v-for="(lesson, index) in tutorial.lessons">
             <li :key="index">
               <LessonLink
+                data-cy="lesson-link"
                 :to="`/${tutorial.url}/${(index + 1).toString().padStart(2, 0)}`"
                 :name="lesson"
                 :index="index + 1" />
             </li>
           </template>
-          <LessonLink v-if="tutorial.resources" :to="resourcesLink" name="More to explore" />
+          <LessonLink data-cy="lesson-link-resources" v-if="tutorial.resources" :to="resourcesLink" name="More to explore" />
         </ul>
       </div>
     </div>

--- a/src/components/Validator.vue
+++ b/src/components/Validator.vue
@@ -42,7 +42,7 @@
     <!-- Text only lesson -->
     <div v-else class="mb3 ph2 tr">
       <div v-if="!nextLessonIsResources && ((lessonNumber === lessonsInTutorial) || isResources)">
-        <Button :click="tutorialMenu" class="bg-aqua white">More Tutorials</Button>
+        <Button :click="tutorialMenu" data-cy="more-tutorials" class="bg-aqua white">More Tutorials</Button>
       </div>
       <div v-else>
         <Button :click="next" class="bg-aqua white">Next</Button>


### PR DESCRIPTION
A new Cypress test loops through all tutorials in `tutorials.json` and ensures that each individual lesson and resources page is listed on the tutorial page and is able to render. This will prevent further errors with routes as recently discovered and fixed in #325 and noted in [this comment](https://github.com/ProtoSchool/protoschool.github.io/issues/323#issuecomment-562629335) on issue #323 (raised by @dominguesgm). This new test is run on every tutorial and lesson (including resources pages) regardless of lesson type.

The existing test built by @olizilla to check that all solution code actually passes validation has been updated slightly to: 
- reflect our new mandatory status for resources pages
- allow simpler updates for which tutorials should have this test run (just add their IDs to the relevant array, which will be looped through)

Note that the current solution for that requires that every single lesson (except the resources page) in a tutorial be a standard coding challenge. 

This PR does NOT close #323 because it doesn't address the issue of testing multiple choice or file upload lessons or ensuring progression works through text only lessons. Once we make those updates we'll likely be able to do more nesting of tests, as in "go to next lesson, if it's X type of lesson, test it like this, repeat." However, I think it stands on its own and can be merged once reviewed, with that issue left open for future improvements.

**A sampling of successfully caught author errors:** 

- If an author screws up the routing in `main.js` as was done previously, the rendering test will fail because the lesson will be listed from the tutorial landing page but clicking it will lead to a Page Not Found: 
```js
  { path: '/mutable-file-system/09', component: T0004L09 },
  { path: '/mutable-file-system/10', component: T0004L10 },
  { path: '/mutable-file-system/01', component: T0004L11 },
```
![image](https://user-images.githubusercontent.com/19171465/70356441-6d5de680-1842-11ea-90f5-2417646511f0.png)
![image](https://user-images.githubusercontent.com/19171465/70356454-7353c780-1842-11ea-8400-3c3b6bcb1552.png)


- If an author forgets to include a resources list in `tutorials.json`, Cypress tests will now fail in two places: 

(a) The rendering test will fail because there will be no line item for a resources page in the tutorial landing page:

![image](https://user-images.githubusercontent.com/19171465/70356173-c9743b00-1841-11ea-85df-4e073fef2d97.png)
![image](https://user-images.githubusercontent.com/19171465/70356181-d3963980-1841-11ea-9a9d-8c973b680d69.png)

(b) The lesson-passing test will fail because the last normal lesson in the tutorial will generate a next button to a /resources URL. At the moment it will actually render a page but with no useful content. 

![image](https://user-images.githubusercontent.com/19171465/70356023-7601ed00-1841-11ea-9866-0e8d1a2d12dd.png)
![image](https://user-images.githubusercontent.com/19171465/70356127-afd2f380-1841-11ea-95dc-3ced3ce972b8.png)


We could call it a bug that we're generating content-less resources pages in the case of this error, but the test will prevent us from committing the error, so it doesn't necessarily need to be fixed. (I caused this error intentionally for testing; all tutorials DO have resources content.)

