### PR TITLE
Display CID strings, not objects

### DIFF
--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -8,8 +8,7 @@
 <script>
 export default {
   data: self => {
-    let cid = self.$attrs.cid
-    cid = cid.toBaseEncodedString ? cid.toBaseEncodedString() : cid
+    let cid = self.$attrs.cid.toString()
     let src = `https://ipfs.io/ipfs/QmeznoNAoUcQdCFEEz4ktv4zLfYYyhVNin28Frsv8LLxCb/?embed=true#/explore/${cid}`
     return {src}
   }

--- a/src/components/Output.vue
+++ b/src/components/Output.vue
@@ -38,12 +38,12 @@ export default {
   },
   computed: {
     exploreIpldUrl: function () {
-      let cid = this.output.test && this.output.test.cid && this.output.test.cid.toBaseEncodedString()
+      let cid = this.output.test && this.output.test.cid && this.output.test.cid.toString()
       cid = cid || ''
       return `https://explore.ipld.io/#/explore/${cid}`
     },
     inspectCidUrl: function () {
-      let cid = this.output.test && this.output.test.cid && this.output.test.cid.toBaseEncodedString()
+      let cid = this.output.test && this.output.test.cid && this.output.test.cid.toString()
       cid = cid || ''
       return `https://cid.ipfs.io/#${cid}`
     }

--- a/src/tutorials/0002/01.vue
+++ b/src/tutorials/0002/01.vue
@@ -31,7 +31,7 @@ const validate = async (result, ipfs) => {
     const expected = JSON.stringify({ test: 1 })
     const got = JSON.stringify(obj.value)
 
-    return { fail: `Was expecting \`${expected}\` but got \`${got}\`.` }
+    return { fail: `Your function returned a CID, but it doesn't have the right contents. It looks like you stored the data \`${got}\` instead of \`${expected}\`.` }
   }
 }
 

--- a/src/tutorials/0002/01.vue
+++ b/src/tutorials/0002/01.vue
@@ -24,7 +24,7 @@ const validate = async (result, ipfs) => {
   }
 
   const hash = 'bafyreicaoyussrycqolu4k2iaxleu2uakjlq57tuxq3djxn4wnyfp4yk3y'
-  if (result.toBaseEncodedString() === hash) {
+  if (result.toString() === hash) {
     return { success: 'Everything works!' }
   } else {
     const obj = await ipfs.dag.get(result)

--- a/src/tutorials/0002/02.vue
+++ b/src/tutorials/0002/02.vue
@@ -27,7 +27,7 @@ const validate = async (result, ipfs) => {
   }
 
   const correctHash = 'bafyreibmdfd7c5db4kls4ty57zljfhqv36gi43l6txl44pi423wwmeskwy'
-  if (result == correctHash) {
+  if (result.toString() === correctHash) {
     return { success: 'Everything works!' }
   } else {
     return { fail: `Was expecting \`${correctHash}\` but got \`${result}\`.` }

--- a/src/tutorials/0002/02.vue
+++ b/src/tutorials/0002/02.vue
@@ -30,7 +30,7 @@ const validate = async (result, ipfs) => {
   if (result.toString() === correctHash) {
     return { success: 'Everything works!' }
   } else {
-    return { fail: `Was expecting \`${correctHash}\` but got \`${result}\`.` }
+    return { fail: `Your function returned a CID, but it doesn't have the right contents. Be sure to \`put\` an object with \`bar\` as the named link and \`cid\` as its value.` }
   }
 }
 

--- a/src/tutorials/0002/02.vue
+++ b/src/tutorials/0002/02.vue
@@ -27,18 +27,9 @@ const validate = async (result, ipfs) => {
   }
 
   const correctHash = 'bafyreibmdfd7c5db4kls4ty57zljfhqv36gi43l6txl44pi423wwmeskwy'
-  console.log(`correctHash: `, correctHash)
-  console.log(typeof correctHash)
-  console.log(`result: `, result)
-  console.log(typeof result)
-  console.log(`loose equality: `, correctHash == result)
-  console.log(`strict equality: `, correctHash === result)
   if (result == correctHash) {
     return { success: 'Everything works!' }
   } else {
-    // const obj = await ipfs.dag.get(result)
-    // const expected = JSON.stringify({ bar: new CID(hash) })
-    // const got = JSON.stringify(obj.value)
     return { fail: `Was expecting \`${correctHash}\` but got \`${result}\`.` }
   }
 }

--- a/src/tutorials/0002/02.vue
+++ b/src/tutorials/0002/02.vue
@@ -17,6 +17,7 @@ import exercise from './02-exercise.md'
 import CID from 'cids'
 
 const validate = async (result, ipfs) => {
+
   if (!result) {
     return { fail: 'You forgot to return a result :)' }
   }
@@ -25,15 +26,20 @@ const validate = async (result, ipfs) => {
     return { fail: 'Did not return a valid CID instance.' }
   }
 
-  const hash = 'bafyreibmdfd7c5db4kls4ty57zljfhqv36gi43l6txl44pi423wwmeskwy'
-  if (result.toBaseEncodedString() === hash) {
+  const correctHash = 'bafyreibmdfd7c5db4kls4ty57zljfhqv36gi43l6txl44pi423wwmeskwy'
+  console.log(`correctHash: `, correctHash)
+  console.log(typeof correctHash)
+  console.log(`result: `, result)
+  console.log(typeof result)
+  console.log(`loose equality: `, correctHash == result)
+  console.log(`strict equality: `, correctHash === result)
+  if (result == correctHash) {
     return { success: 'Everything works!' }
   } else {
-    const obj = await ipfs.dag.get(result)
-    const expected = JSON.stringify({ bar: new CID(hash) })
-    const got = JSON.stringify(obj.value)
-
-    return { fail: `Was expecting \`${expected}\` but got \`${got}\`.` }
+    // const obj = await ipfs.dag.get(result)
+    // const expected = JSON.stringify({ bar: new CID(hash) })
+    // const got = JSON.stringify(obj.value)
+    return { fail: `Was expecting \`${correctHash}\` but got \`${result}\`.` }
   }
 }
 

--- a/src/tutorials/0003/01.vue
+++ b/src/tutorials/0003/01.vue
@@ -35,7 +35,7 @@ const validate = async (result, ipfs) => {
       return { fail: 'The value of `author` needs to be a link (`{"/": "some-cid"}`).' }
     }
     const nodeAuthor = node.author
-    if (![natCid, samCid].includes(nodeAuthor.toBaseEncodedString())) {
+    if (![natCid, samCid].includes(nodeAuthor.toString())) {
       return { fail: 'You need to link to the CID of an author (Nat or Sam).' }
     }
     let expectedAuthor
@@ -47,12 +47,12 @@ const validate = async (result, ipfs) => {
         expectedAuthor = natCid
         break
     }
-    if (nodeAuthor.toBaseEncodedString() !== expectedAuthor) {
+    if (nodeAuthor.toString() !== expectedAuthor) {
       return { fail: `The author of the \`${node.content}\` blog post (${nodeAuthor}) did not match the the expected author (${expectedAuthor}).` }
     }
   }
   const expectedCids = ['bafyreiaahxu4lot4ffzaxnz626kxipxt3lm43lsszcc4q6vydqrwnu7kpi', 'bafyreif24ddeqipektksc2jqhulgefwvhwhpylpkmjsdysxygllyeydwqq']
-  const resultCids = result.map((cid) => cid.toBaseEncodedString())
+  const resultCids = result.map((cid) => cid.toString())
   if (shallowEqualArrays(resultCids.sort(), expectedCids.sort())) {
     return { success: 'Everything works!' }
   } else {

--- a/src/tutorials/0003/02.md
+++ b/src/tutorials/0003/02.md
@@ -2,4 +2,4 @@ Everything that is stored in IPFS has an associated CID. That CID is constructed
 
 Our blog doesn't have any tags yet. Let’s modify the posts again to add some tags, watching how the CID for each post changes as we change its contents.
 
-First, submit the code in its current state. You’ll see the CIDs of the blog posts. When you submit again after you’ve modified the code, you’ll see that the CIDs have changed. (We use [`CID.toBaseEncodedString()`](https://github.com/multiformats/js-cid#cidtobaseencodedstringbasethismultibasename) to access the CID as a string for purposes of logging.)
+First, submit the code in its current state. You’ll see the CIDs of the blog posts. When you submit again after you’ve modified the code, you’ll see that the CIDs have changed.

--- a/src/tutorials/0003/02.vue
+++ b/src/tutorials/0003/02.vue
@@ -26,11 +26,11 @@ const validate = async (result, ipfs) => {
 
   const TREE_POST_CID = 'bafyreiaahxu4lot4ffzaxnz626kxipxt3lm43lsszcc4q6vydqrwnu7kpi'
   const COMPUTER_POST_CID = 'bafyreif24ddeqipektksc2jqhulgefwvhwhpylpkmjsdysxygllyeydwqq'
-  if (TREE_POST_CID === result[0].toBaseEncodedString() && COMPUTER_POST_CID === result[1].toBaseEncodedString()) {
+  if (TREE_POST_CID === result[0].toString() && COMPUTER_POST_CID === result[1].toString()) {
     return {
       log: {
-        treePostCid: result[0].toBaseEncodedString(),
-        computerPostCid: result[1].toBaseEncodedString()
+        treePostCid: result[0].toString(),
+        computerPostCid: result[1].toString()
       }
     }
   }
@@ -68,8 +68,8 @@ const validate = async (result, ipfs) => {
     success: 'Everything works!',
     logDesc: 'These are the CIDs of the blog posts. Notice how they change when the underlying data is altered.',
     log: {
-      treePostCid: result[0].toBaseEncodedString(),
-      computerPostCid: result[1].toBaseEncodedString()
+      treePostCid: result[0].toString(),
+      computerPostCid: result[1].toString()
     }
   }
 }

--- a/src/tutorials/0003/03.vue
+++ b/src/tutorials/0003/03.vue
@@ -56,7 +56,7 @@ const validate = async (result, ipfs) => {
       default:
         return { fail: `Wrong tag (${node.tag}). Did you mean \`hobby\` or \`outdoor\`?` }
     }
-    const nodePosts = node.posts.map(post => post.toBaseEncodedString())
+    const nodePosts = node.posts.map(post => post.toString())
     if (!shallowEqualArrays(nodePosts.sort(), expectedPosts.sort())) {
       return { fail: `The posts of the tag \`${node.tag}\` ${utils.stringify(nodePosts)} did not match the the expected posts ${utils.stringify(expectedPosts)}.` }
     }

--- a/src/tutorials/0003/04.vue
+++ b/src/tutorials/0003/04.vue
@@ -36,7 +36,7 @@ const validate = async (result, ipfs) => {
     return { fail: 'The value of `author` needs to be a link.' }
   }
   const samCid = 'bafyreigq4aqwo7fisdgkwxao6r6jdcw6pjvqkgeaadwsc2mgzvybuoa4sy'
-  const nodeAuthor = node.author.toBaseEncodedString()
+  const nodeAuthor = node.author.toString()
   if (nodeAuthor !== samCid) {
     return { fail: 'The author of the new blog post needs to be `Sam`.' }
   }

--- a/src/tutorials/0003/05.vue
+++ b/src/tutorials/0003/05.vue
@@ -62,7 +62,7 @@ const validate = async (result, ipfs) => {
       default:
         return { fail: `Wrong tag (${node.tag}). Did you mean one of funny, hobby, outdoor?` }
     }
-    const nodePosts = node.posts.map(post => post.toBaseEncodedString())
+    const nodePosts = node.posts.map(post => post.toString())
     if (!shallowEqualArrays(nodePosts.sort(), expectedPosts.sort())) {
       return { fail: `The posts of the tag \`${node.tag}\` ${utils.stringify(nodePosts)} did not match the the expected posts ${utils.stringify(expectedPosts)}.` }
     }

--- a/src/tutorials/0003/06.vue
+++ b/src/tutorials/0003/06.vue
@@ -65,17 +65,17 @@ const validate = async (result, ipfs) => {
     return { fail: 'The `trees` blog post shouldn\'t link to other blog posts.' }
   }
 
-  const computerNodePrevCid = computerNodePrev.toBaseEncodedString()
+  const computerNodePrevCid = computerNodePrev.toString()
   if (![treePostCid, treePostCidPrevNull].includes(computerNodePrevCid)) {
     return { fail: `The \`computers\` blog post should link to the \`trees\` blog post, but it links to ${computerNodePrevCid}.` }
   }
 
-  const nodePrevCid = nodePrev.toBaseEncodedString()
+  const nodePrevCid = nodePrev.toString()
   if (![computerPostCid, computerPostCidWhenTreePostCidPrevNull].includes(nodePrevCid)) {
     return { fail: `The "dogs" blog post should link to the "computers" blog post, but it links to ${nodePrevCid}.` }
   }
 
-  const nodeCid = result.toBaseEncodedString()
+  const nodeCid = result.toString()
   if (nodeCid === dogPostCid || dogPostCidWhenTreePostCidPrevNull) {
     return { success: 'Everything works!' }
   } else {

--- a/src/tutorials/0003/07.vue
+++ b/src/tutorials/0003/07.vue
@@ -50,7 +50,7 @@ const validate = async (result, ipfs) => {
       return { fail: 'Your traversePosts function needs to return CIDs.' }
     }
     const expectedCids = [treePostCid, computerPostCid, dogPostCid]
-    const returnedCids = result.map(item => item.toBaseEncodedString())
+    const returnedCids = result.map(item => item.toString())
     if (!shallowEqualArrays(returnedCids.sort(), expectedCids.sort())) {
       return {
         fail: 'The CIDs returned by the traversePosts function did not match the expected CIDs.',


### PR DESCRIPTION
@mikeal this is a first stab at a fix to the issue @lanzafame raised in #120 where we were printing CID objects instead of just CID strings. 

This works and displays both CIDs as strings in the output when they don't match, but in order to make it recognize a correct answer in this approach I had to switch to loose equality to make the result (a CID which comes as an object) match the correct CID (expressed as a string). Is it safe to do it this way or would you recommend some kind of actual conversion? 

I'll circle around and look for other cases of this problem to fix after confirming whether this approach feels reasonable. 