### PR TITLE
Add video from IPFS Camp Core Course D to resources pages

### DIFF
--- a/src/components/Resources.vue
+++ b/src/components/Resources.vue
@@ -10,7 +10,7 @@
         <a class='b blue link' :href='item.link' target='_blank'>{{item.title}}</a>
         <span class='ml2 ph2 bg-navy br-pill white f7'>{{item.type}}</span>
         <span
-          v-if='item.link.includes('/proto.school/')'
+          v-if='item.link.includes("/proto.school/")'
           class='ml2 ph2 bg-aqua br-pill white f7'
         >ProtoSchool</span>
       </p>
@@ -35,7 +35,7 @@ export default {
 </script>
 
 <style>
-.resource-desc > p {
+.resource-desc p {
   margin-top: 0;
 }
 </style>

--- a/src/components/Resources.vue
+++ b/src/components/Resources.vue
@@ -7,15 +7,28 @@
         <span class="ml2 ph2 bg-navy br-pill white f7">{{item.type}}</span>
         <span v-if="item.link.includes('/proto.school/')" class="ml2 ph2 bg-aqua br-pill white f7">ProtoSchool</span>
       </p>
-      <p v-if="item.description" class="ma0">{{item.description}}</p>
+      <div v-if="item.description" class="ma0 resource-desc" v-html="parse(item.description)"></div>
     </div>
   </div>
 </template>
 
 <script>
+import marked from 'marked'
+
 export default {
   props: {
     data: Array
+  },
+  methods: {
+    parse(description) {
+      return marked(description || '')
+    }
   }
 }
 </script>
+
+<style>
+.resource-desc p {
+  margin-top: 0;
+}
+</style>

--- a/src/components/Resources.vue
+++ b/src/components/Resources.vue
@@ -35,7 +35,7 @@ export default {
 </script>
 
 <style>
-.resource-desc p {
+.resource-desc > p {
   margin-top: 0;
 }
 </style>

--- a/src/components/Resources.vue
+++ b/src/components/Resources.vue
@@ -1,34 +1,41 @@
 <template>
-  <div data-cy="resources-content" class="lesson-text lh-copy">
-    <p>Ready to learn more? There are plenty of additional resources to explore, both in ProtoSchool and beyond. <span v-if="data.length > 1">Here are some of our favorites:</span> <span v-else>Here's our top pick:</span></p>
-    <div v-for="(item, idx) in data" :key="`resources-${idx}`" class="mb3">
-      <p class="ma0 flex items-center">
-        <a class="b blue link" :href="item.link" target="_blank">{{item.title}}</a>
-        <span class="ml2 ph2 bg-navy br-pill white f7">{{item.type}}</span>
-        <span v-if="item.link.includes('/proto.school/')" class="ml2 ph2 bg-aqua br-pill white f7">ProtoSchool</span>
+  <div data-cy='resources-content' class='lesson-text lh-copy'>
+    <p>
+      Ready to learn more? There are plenty of additional resources to explore, both in ProtoSchool and beyond.
+      <span v-if='data.length > 1'>Here are some of our favorites:</span>
+      <span v-else>Here's our top pick:</span>
+    </p>
+    <div v-for='(item, idx) in data' :key='`resources-${idx}`' class='mb3'>
+      <p class='ma0 flex items-center'>
+        <a class='b blue link' :href='item.link' target='_blank'>{{item.title}}</a>
+        <span class='ml2 ph2 bg-navy br-pill white f7'>{{item.type}}</span>
+        <span
+          v-if='item.link.includes('/proto.school/')'
+          class='ml2 ph2 bg-aqua br-pill white f7'
+        >ProtoSchool</span>
       </p>
-      <div v-if="item.description" class="ma0 resource-desc" v-html="parse(item.description)"></div>
+      <div v-if='item.description' class='ma0 resource-desc' v-html='parse(item.description)'></div>
     </div>
   </div>
 </template>
 
 <script>
-import marked from 'marked'
+import marked from 'marked';
 
 export default {
   props: {
     data: Array
   },
   methods: {
-    parse(description) {
-      return marked(description || '')
+    parse: function(description) {
+      return marked(description || '');
     }
   }
-}
+};
 </script>
 
 <style>
-.resource-desc p {
+.resource-desc > p {
   margin-top: 0;
 }
 </style>

--- a/src/static/tutorials.json
+++ b/src/static/tutorials.json
@@ -100,7 +100,7 @@
 				"title": "The Lifecycle of Data in the DWeb",
 				"link": "https://youtu.be/fLUq0RkiTBA",
 				"type": "video",
-				"description": "Ready to explore what happens _after_ you've added data to IPFS? This IPFS Camp 2019 course covers how peers discover and share files on the network, from providing to getting to pinning to deleting."
+				"description": "Curious about what happens _after_ you've added data to IPFS? This IPFS Camp 2019 course explores how peers discover and share files on the network, from providing to getting to pinning to deleting."
 			},
 			{
 				"title": "IPFS: Regular Files API",
@@ -140,7 +140,7 @@
 				"title": "The Lifecycle of Data in the DWeb",
 				"link": "https://youtu.be/fLUq0RkiTBA",
 				"type": "video",
-				"description": "Ready to explore what happens _after_ you've added data to IPFS? This IPFS Camp 2019 course covers how peers discover and share files on the network, from providing to getting to pinning to deleting."
+				"description": "Curious about what happens _after_ you've added data to IPFS? This IPFS Camp 2019 course explores how peers discover and share files on the network, from providing to getting to pinning to deleting."
 			},
 			{
 				"title": "IPFS: Regular Files API",
@@ -185,7 +185,7 @@
 				"title": "The Lifecycle of Data in the DWeb",
 				"link": "https://youtu.be/fLUq0RkiTBA",
 				"type": "video",
-				"description": "Curious about what happens _after_ you've added files to IPFS? This course from IPFS Camp 2019 covers how peers discover and share files on the network, from providing to getting to pinning to deleting."
+				"description": "Curious about what happens _after_ you've added files to IPFS? This course from IPFS Camp 2019 explores how peers discover and share files on the network, from providing to getting to pinning to deleting."
 			},
 			{
 				"title": "IPFS: Regular Files API",
@@ -245,7 +245,7 @@
 				"title": "The Lifecycle of Data in the DWeb",
 				"link": "https://youtu.be/fLUq0RkiTBA",
 				"type": "video",
-				"description": "Curious about what happens _after_ you've added files to IPFS? This course from IPFS Camp 2019 covers how peers discover and share files on the network, from providing to getting to pinning to deleting."
+				"description": "Curious about what happens _after_ you've added files to IPFS? This course from IPFS Camp 2019 explores how peers discover and share files on the network, from providing to getting to pinning to deleting."
 			},
 			{
 				"title": "IPFS: Mutable File System (MFS)",

--- a/src/static/tutorials.json
+++ b/src/static/tutorials.json
@@ -1,6 +1,6 @@
 {
 	"0001": {
-    "url": "data-structures",
+		"url": "data-structures",
 		"project": "IPFS",
 		"title": "Decentralized data structures",
 		"description": "The decentralized web relies on unique data structures and linking strategies. Learn about the benefits of hashing, content addressing, DAG and Merkle Trees!",
@@ -11,20 +11,26 @@
 			"Cryptographic hashing and Content Identifiers (CIDs)",
 			"Merkle trees and directed acyclic graphs (DAG)"
 		],
-	  "resources": [
+		"resources": [
 			{
-				 "title": "Understanding How IPFS Deals with Files",
-				 "link": "https://youtu.be/Z5zNPwMDYGg",
-				 "type": "video",
-				 "description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports."
-			 },
+				"title": "Understanding How IPFS Deals with Files",
+				"link": "https://youtu.be/Z5zNPwMDYGg",
+				"type": "video",
+				"description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports."
+			},
+			{
+				"title": "The Lifecycle of Data in the DWeb",
+				"link": "https://youtu.be/fLUq0RkiTBA",
+				"type": "video",
+				"description": "This course from IPFS Camp 2019 explores how users share files on IPFS, from providing to getting to pinning to deleting."
+			},
 			{
 				"title": "Decentralized Web Primer: The Power of Content-Addressing",
 				"link": "https://flyingzumwalt.gitbooks.io/decentralized-web-primer/content/avenues-for-access/lessons/power-of-content-addressing.html",
 				"type": "article",
 				"description": "A beginner-friendly primer on content addressing from Matt Zumwalt."
 			},
- 			{
+			{
 				"title": "The Next Internet Revolution",
 				"link": "https://www.youtube.com/watch?v=2RCwZDRwk48&feature=youtu.be&t=847",
 				"type": "video",
@@ -42,7 +48,8 @@
 				"type": "article",
 				"description": "Matt Zumwalt of IPFS explains why data isn't safe on the centralized web and how IPFS can be used to protect it."
 			},
-			{ "title": "HTTP is Obsolete. It's Time for the Distributed, Permanent Web.",
+			{
+				"title": "HTTP is Obsolete. It's Time for the Distributed, Permanent Web.",
 				"link": "https://ipfs.io/ipfs/QmNhFJjGcMPqpuYfxL62VVB9528NXqDNMFXiqN5bgFYiZ1/its-time-for-the-permanent-web.html",
 				"type": "article",
 				"description": "Kyle Drake of Neocities explores the downsides of the Hypertext Transfer Protocol (HTTP)."
@@ -62,7 +69,7 @@
 		]
 	},
 	"0002": {
-    "url": "basics",
+		"url": "basics",
 		"project": "IPFS",
 		"title": "P2P data links with content addressing",
 		"description": "Store, fetch, and create verifiable links between peer-hosted datasets using the IPFS DAG API and CIDs. It’s graphs with friends!",
@@ -71,32 +78,40 @@
 			"Create a new node that's linked to an old one",
 			"Read nested data using link"
 		],
-	  "resources": [
-	    { "title": "JS-IPFS DAG API",
+		"resources": [
+			{
+				"title": "JS-IPFS DAG API",
 				"link": "https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/DAG.md",
 				"type": "docs"
 			},
-			{ "title": "Blogging on the Decentralized Web",
+			{
+				"title": "Blogging on the Decentralized Web",
 				"link": "https://proto.school/#/blog/",
 				"type": "tutorial",
 				"description": "Ready for a bigger challenge with the IPFS DAG API? Use CIDs to build and update a complex web of data."
 			},
 			{
-				 "title": "Understanding How IPFS Deals with Files",
-				 "link": "https://youtu.be/Z5zNPwMDYGg",
-				 "type": "video",
-				 "description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports."
-			 },
-			 {
-				 "title": "IPFS: Regular Files API",
-				 "link": "https://proto.school/#/regular-files-api",
-				 "type": "tutorial",
-				 "description": "Ready to deal with more than primitives? Explore the API custom-built for efficient handling of files in IPFS."
-			 }
-	  ]
+				"title": "Understanding How IPFS Deals with Files",
+				"link": "https://youtu.be/Z5zNPwMDYGg",
+				"type": "video",
+				"description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports."
+			},
+			{
+				"title": "The Lifecycle of Data in the DWeb",
+				"link": "https://youtu.be/fLUq0RkiTBA",
+				"type": "video",
+				"description": "Ready to explore what happens _after_ you've added data to IPFS? This IPFS Camp 2019 course covers how peers discover and share files on the network, from providing to getting to pinning to deleting."
+			},
+			{
+				"title": "IPFS: Regular Files API",
+				"link": "https://proto.school/#/regular-files-api",
+				"type": "tutorial",
+				"description": "Ready to deal with more than primitives? Explore the API custom-built for efficient handling of files in IPFS."
+			}
+		]
 	},
 	"0003": {
-    "url": "blog",
+		"url": "blog",
 		"project": "IPFS",
 		"title": "Blogging on the Decentralized Web",
 		"description": "Cool content addresses don't change.",
@@ -109,27 +124,34 @@
 			"List posts chronologically with a chain of links",
 			"Traverse through all posts, starting with the most recent"
 		],
-	  "resources": [
-	    { "title": "JS-IPFS DAG API",
+		"resources": [
+			{
+				"title": "JS-IPFS DAG API",
 				"link": "https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/DAG.md",
 				"type": "docs"
 			},
 			{
-				 "title": "Understanding How IPFS Deals with Files",
-				 "link": "https://youtu.be/Z5zNPwMDYGg",
-				 "type": "video",
-				 "description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports."
-			 },
-			 {
-				 "title": "IPFS: Regular Files API",
-				 "link": "https://proto.school/#/regular-files-api",
-				 "type": "tutorial",
-				 "description": "Ready to deal with more than primitives? Explore the API custom-built for efficient handling of files in IPFS."
-			 }
-	  ]
+				"title": "Understanding How IPFS Deals with Files",
+				"link": "https://youtu.be/Z5zNPwMDYGg",
+				"type": "video",
+				"description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports."
+			},
+			{
+				"title": "The Lifecycle of Data in the DWeb",
+				"link": "https://youtu.be/fLUq0RkiTBA",
+				"type": "video",
+				"description": "Ready to explore what happens _after_ you've added data to IPFS? This IPFS Camp 2019 course covers how peers discover and share files on the network, from providing to getting to pinning to deleting."
+			},
+			{
+				"title": "IPFS: Regular Files API",
+				"link": "https://proto.school/#/regular-files-api",
+				"type": "tutorial",
+				"description": "Ready to deal with more than primitives? Explore the API custom-built for efficient handling of files in IPFS."
+			}
+		]
 	},
 	"0004": {
-    "url": "mutable-file-system",
+		"url": "mutable-file-system",
 		"project": "IPFS",
 		"title": "IPFS: Mutable File System",
 		"description": "The Mutable File System (MFS) lets you work with files and directories as if you were using a traditional name-based file system.",
@@ -146,7 +168,7 @@
 			"Read the contents of a file",
 			"Remove a file or directory"
 		],
-	  "resources": [
+		"resources": [
 			{
 				"title": "JS-IPFS Files API",
 				"link": "https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/FILES.md",
@@ -154,23 +176,28 @@
 				"description": "Notice that these docs contain two sections, one for top-level methods relevant to files and one for the Mutable File System (MFS) you learned about in this tutorial."
 			},
 			{
-				 "title": "Understanding How IPFS Deals with Files",
-				 "link": "https://youtu.be/Z5zNPwMDYGg",
-				 "type": "video",
-				 "description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports. It also introduces some the joys and pitfalls of the Mutable File System (MFS)."
-			 },
-			 {
-				 "title": "IPFS: Regular Files API",
-				 "link": "https://proto.school/#/regular-files-api",
-				 "type": "tutorial",
-				 "description": "Explore the other half of the IPFS Files API, where you'll add and retrieve files and read their contents without the abstraction layer of the Mutable File System."
-			 },
+				"title": "Understanding How IPFS Deals with Files",
+				"link": "https://youtu.be/Z5zNPwMDYGg",
+				"type": "video",
+				"description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports. It also introduces some the joys and pitfalls of the Mutable File System (MFS)."
+			},
+			{
+				"title": "The Lifecycle of Data in the DWeb",
+				"link": "https://youtu.be/fLUq0RkiTBA",
+				"type": "video",
+				"description": "Curious about what happens _after_ you've added files to IPFS? This course from IPFS Camp 2019 covers how peers discover and share files on the network, from providing to getting to pinning to deleting."
+			},
+			{
+				"title": "IPFS: Regular Files API",
+				"link": "https://proto.school/#/regular-files-api",
+				"type": "tutorial",
+				"description": "Explore the other half of the IPFS Files API, where you'll add and retrieve files and read their contents without the abstraction layer of the Mutable File System."
+			},
 			{
 				"title": "Browser MFS Demo",
 				"link": "https://github.com/ipfs/js-ipfs/tree/master/examples/browser-mfs",
 				"type": "demo",
 				"description": "Try out MFS methods in your broswer and watch your file directory change as you go."
-
 			},
 			{
 				"title": "Jeromy Coffee Talks: Files API",
@@ -203,30 +230,35 @@
 		],
 		"resources": [
 			{
-				 "title": "JS-IPFS Files API",
-				 "link": "https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/FILES.md",
-				 "type": "docs",
-				 "description": "Notice that these docs contain two sections, one for top-level methods relevant to files, which we learned about in this tutorial, and one for the Mutable File System (MFS)."
-			 },
-			 {
-				 "title": "Understanding How IPFS Deals with Files",
-				 "link": "https://youtu.be/Z5zNPwMDYGg",
-				 "type": "video",
-				 "description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports. It also introduces some the joys and pitfalls of the Mutable File System (MFS)."
-			 },
-
-				{
-					"title": "IPFS: Mutable File System (MFS)",
-					"link": "https://proto.school/#/mutable-file-system",
-					"type": "tutorial",
-					"description": "Wish adding files to IPFS felt more like using a traditional name-based file system? Explore the Mutable File System (MFS)."
-				},
-				{
-					"title": "P2P Data Links with Content Addressing",
-					"link": "https://proto.school/#/basics/",
-					"type": "tutorial",
-					"description": "You've seen the IPFS Files API. Now explore the IPFS DAG API, where you'll use CIDs to create verifiable links between datasets."
-				}
-			]
+				"title": "JS-IPFS Files API",
+				"link": "https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/FILES.md",
+				"type": "docs",
+				"description": "Notice that these docs contain two sections, one for top-level methods relevant to files, which we learned about in this tutorial, and one for the Mutable File System (MFS)."
+			},
+			{
+				"title": "Understanding How IPFS Deals with Files",
+				"link": "https://youtu.be/Z5zNPwMDYGg",
+				"type": "video",
+				"description": "This course from IPFS Camp 2019 offers a deep exploration of how IPFS deals with files, including key concepts like immutability, content addressing, hashing, the anatomy of CIDs, what the heck a Merkle DAG is, and how chunk size affects file imports. It also introduces some the joys and pitfalls of the Mutable File System (MFS)."
+			},
+			{
+				"title": "The Lifecycle of Data in the DWeb",
+				"link": "https://youtu.be/fLUq0RkiTBA",
+				"type": "video",
+				"description": "Curious about what happens _after_ you've added files to IPFS? This course from IPFS Camp 2019 covers how peers discover and share files on the network, from providing to getting to pinning to deleting."
+			},
+			{
+				"title": "IPFS: Mutable File System (MFS)",
+				"link": "https://proto.school/#/mutable-file-system",
+				"type": "tutorial",
+				"description": "Wish adding files to IPFS felt more like using a traditional name-based file system? Explore the Mutable File System (MFS)."
+			},
+			{
+				"title": "P2P Data Links with Content Addressing",
+				"link": "https://proto.school/#/basics/",
+				"type": "tutorial",
+				"description": "You've seen the IPFS Files API. Now explore the IPFS DAG API, where you'll use CIDs to create verifiable links between datasets."
+			}
+		]
 	}
 }


### PR DESCRIPTION
Closes #333 by adding a link to the video from IPFS Camp Core Course D (Lifecycle of Data in the DWeb) to all existing resources pages, with slightly different descriptions depending what the user has already learned. 

Also adds markdown functionality for resource descriptions by importing `marked`. Because the text now pulls in as inner HTML, as a child of the div we created directly, I found I need to create a new custom class to adjust the spacing on the `p` element that pulls in (to keep the description directly under the resource title). As far as I know I can't use Tachyons directly to affect the child of the element I have access to. 