### PR TITLE
chore: improved button disabled status

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -33,8 +33,10 @@ button:active {
 }
 
 button:disabled {
-  opacity: 0.8;
+  opacity: 0.95;
   box-shadow: initial;
   cursor: default;
+  color: #b9c4cd;
+  background-color: #8498a6;
 }
 </style>

--- a/src/components/Validator.vue
+++ b/src/components/Validator.vue
@@ -3,49 +3,49 @@
     <!-- Coding lesson -->
     <div v-if="exercise" :class="{'fixed bottom-0 right-0': expandExercise}" class="coding-exercise-container pr4 pb4 tr">
       <div v-if="!nextLessonIsResources && (lessonPassed && (lessonNumber === lessonsInTutorial)) || isResources">
-        <Button :click="tutorialMenu" class="bg-aqua white" data-cy="more-tutorials">More Tutorials</Button>
+        <Button :click="tutorialMenu" class="bg-navy white" data-cy="more-tutorials">More Tutorials</Button>
       </div>
       <div v-else-if="lessonPassed && !isSubmitting">
         <span class="disabled-btn-wrapper">
           <span v-if="isFileLesson && !uploadedFiles" class="mr2 red lh-copy o-0">
             You must upload a file before submitting.
           </span>
-          <Button v-if="(isFileLesson && !output) || (isFileLesson && !uploadedFiles)" :disabled="!uploadedFiles" :click="run" class="mr2 bg-aqua white" style="minWidth: 90px">Submit</Button>
+          <Button v-if="(isFileLesson && !output) || (isFileLesson && !uploadedFiles)" :disabled="!uploadedFiles" :click="run" class="mr2 bg-navy white" style="minWidth: 90px">Submit</Button>
         </span>
-        <Button :click="next" class="bg-aqua white" data-cy="next-lesson">Next</Button>
+        <Button :click="next" class="bg-navy white" data-cy="next-lesson">Next</Button>
       </div>
       <div v-else>
         <span v-if="(isFileLesson && !uploadedFiles) || isSubmitting" class="disabled-btn-wrapper">
           <span v-if="isFileLesson && !uploadedFiles" class="mr2 red lh-copy o-0">
             You must upload a file before submitting.
           </span>
-          <Button :click="next" class="bg-aqua white" disabled>
+          <Button :click="next" class="bg-navy white" disabled>
             <span v-if="isSubmitting" class="loader"></span>
             <span v-else>Submit</span>
           </Button>
         </span>
-        <Button v-else :click="run" class="bg-aqua white" data-cy="submit-answer">Submit</Button>
+        <Button v-else :click="run" class="bg-navy white" data-cy="submit-answer">Submit</Button>
       </div>
     </div>
     <!-- Multiple choice lesson -->
     <div v-else-if="isMultipleChoiceLesson" class="coding-exercise-container pr4 pb4 tr">
       <div v-if="!nextLessonIsResources && (lessonPassed && (lessonNumber === lessonsInTutorial)) || isResources">
-        <Button :click="tutorialMenu" class="bg-aqua white" data-cy="more-tutorials">More Tutorials</Button>
+        <Button :click="tutorialMenu" class="bg-navy white" data-cy="more-tutorials">More Tutorials</Button>
       </div>
       <span v-else class="disabled-btn-wrapper">
         <span v-if="!lessonPassed" class="mr2 red lh-copy o-0">
           Oops, you haven't selected the right answer yet!
         </span>
-        <Button :click="next" class="bg-aqua white" :disabled="!lessonPassed" data-cy="next-lesson">Next</Button>
+        <Button :click="next" class="bg-navy white" :disabled="!lessonPassed" data-cy="next-lesson">Next</Button>
       </span>
     </div>
     <!-- Text only lesson -->
     <div v-else class="mb3 ph2 tr">
       <div v-if="!nextLessonIsResources && ((lessonNumber === lessonsInTutorial) || isResources)">
-        <Button :click="tutorialMenu" data-cy="more-tutorials" class="bg-aqua white">More Tutorials</Button>
+        <Button :click="tutorialMenu" data-cy="more-tutorials" class="bg-navy white">More Tutorials</Button>
       </div>
       <div v-else>
-        <Button :click="next" class="bg-aqua white">Next</Button>
+        <Button :click="next" class="bg-navy white">Next</Button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Updated disabled button styles to match @ericronne's recommendation in #317.

<img width="543" alt="Screenshot 2020-01-09 at 15 26 48" src="https://user-images.githubusercontent.com/4084119/72080327-83087500-32f4-11ea-965f-f033de652bd5.png">

One thing to note is that as the button is disabled in the loading state, it will show up with the new disabled style. We need to discuss whether this is appropriate or not @terichadbourne @zebateira.

<img width="151" alt="Screenshot 2020-01-09 at 16 33 26" src="https://user-images.githubusercontent.com/4084119/72085806-dcc16d00-32fd-11ea-917d-c65ad7e1c544.png">
