### PR TITLE
Fix tutorial URLs

### DIFF
--- a/src/utils/tutorials.js
+++ b/src/utils/tutorials.js
@@ -5,6 +5,6 @@ export const getCurrentTutorial = route => (
     tutorialsList[route.props.default.tutorialId]
 )
 
-export const getTutorialFullUrl = tutorial => `${window.location.origin}/${tutorial.url}`
+export const getTutorialFullUrl = tutorial => `${window.location.origin}/#/${tutorial.url}`
 
 export const isTutorialPassed = tutorial => !!localStorage[`passed/${tutorial.url}`]


### PR DESCRIPTION
@zebateira A couple of folks used the new Twitter feature recently but I clicked through on the links and reached a 404 because the hash was missing in the URL. Feel free to merge if you agree that this little tweak fixes the issue. 

![image](https://user-images.githubusercontent.com/19171465/73234216-24962000-4157-11ea-9e6f-ceb1550c62b1.png)

Interestingly hitting a GitHub-generated 404 and not our own - will this case be fixed by the routing PR you have in progress by any chance?

![image](https://user-images.githubusercontent.com/19171465/73234156-fadcf900-4156-11ea-9c62-67ef5809c22b.png)

