### PR TITLE
Remove sample URLs from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/lesson-feedback.md
+++ b/.github/ISSUE_TEMPLATE/lesson-feedback.md
@@ -10,7 +10,6 @@ assignees: ''
 Have a question or suggestion regarding a specific ProtoSchool lesson? Please use this template to share it!
 
 **URL of the lesson that's confusing:**
-eg https://proto.school/#/blog/01
 
 **What's confusing about this lesson?**
 

--- a/.github/ISSUE_TEMPLATE/tutorial-feedback.md
+++ b/.github/ISSUE_TEMPLATE/tutorial-feedback.md
@@ -12,7 +12,6 @@ Have you recently completed a ProtoSchool tutorial? Please share your feedback!
 **Tutorial name:**
 
 **Tutorial URL:**
-_eg https://proto.school/#/blog_
 
 **Would you recommend this tutorial to others?**
 


### PR DESCRIPTION
Removing the sample URL because people keep leaving it there instead of filling in the section. 