### PR TITLE
fix: mark resources "lesson" as passed on page mount

### DIFF
--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -265,6 +265,12 @@ export default {
   beforeMount: function () {
     this.choice = localStorage[this.cacheKey] || ''
   },
+  mounted: function () {
+    if (this.isResources) {
+      localStorage[this.lessonKey] = 'passed'
+      this.trackEvent(EVENTS.LESSON_PASSED)
+    }
+  },
   methods: {
     setEditorCode (newCode) {
       localStorage[this.cacheKey] = newCode

--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -469,7 +469,7 @@ export default {
         key: event,
         segmentation: {
           tutorial: this.tutorial.shortTitle,
-          lessonNumber: this.lessonId,
+          lessonNumber: this.isResources ? 'resources' : this.lessonId,
           path: this.$route.path,
           ...opts
         }


### PR DESCRIPTION
This PR fixes the issue of when the resources lesson only gets marked as completed after you click the button "More Tutorials" at the end of the page.
For this we mark the lesson as completed when the page mounts

Closes #368 