### PR TITLE
ipfs@0.41 update: option 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30259,6 +30259,11 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "it-all": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.1.tgz",
+      "integrity": "sha512-DQ8MQXVfwCktZOja1xvKdsuka7E/OJHpLKLR3tMBmg6Kfo8Kob+XRE6pRfpbkXNsGyET4lMYrQ0y5T3XXF/Akw=="
+    },
     "javascript-stringify": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "highlight.js": "^9.12.0",
     "ipfs": "^0.41.0",
     "ipfs-css": "^0.6.0",
+    "it-all": "^1.0.1",
     "meta-marked": "^0.4.2",
     "monaco-editor": "^0.6.1",
     "new-github-issue-url": "^0.2.1",

--- a/src/tutorials/0005-regular-files-api/03.js
+++ b/src/tutorials/0005-regular-files-api/03.js
@@ -1,7 +1,9 @@
+import all from 'it-all'
+
 const validate = async (result, ipfs) => {
   const uploadedFiles = window.uploadedFiles || false
 
-  const expectedResult = await ipfs.add(window.uploadedFiles)
+  const expectedResult = await all(ipfs.add(window.uploadedFiles))
 
   if (!result) {
     return {
@@ -47,8 +49,10 @@ const validate = async (result, ipfs) => {
 }
 
 const code = `/* global ipfs */
+const all = require('it-all')
+
 const run = async (files) => {
-  const result = // Place your code to add a file or files here
+  const result = all() // Place your code to add a file or files here
 
   return result
 }
@@ -56,15 +60,17 @@ return run
 `
 
 const solution = `/* global ipfs */
+const all = require('it-all')
+
 const run = async (files) => {
-  const result = await ipfs.add(files)
+  const result = await all(ipfs.add(files))
 
   return result
 }
 return run
 `
 
-const modules = { cids: require('cids') }
+const modules = { 'it-all': require('it-all') }
 
 const options = {
   overrideErrors: true


### PR DESCRIPTION
Second option for dealing with the new js ipfs api that always returns iterables.
This second approach uses the `it-all` package from @achingbrain.

<img width="376" alt="Screen Shot 2020-02-17 at 7 06 01 PM" src="https://user-images.githubusercontent.com/2353186/74666631-4a916c00-51bb-11ea-8c29-88e2f95ade22.png">

- A bit more clean but it might be confusing for users to understand where to use the `all` function

See original WIP PR: #381