### PR TITLE
ipfs@0.41 update: option 1

### DIFF
--- a/src/tutorials/0005-regular-files-api/03.js
+++ b/src/tutorials/0005-regular-files-api/03.js
@@ -1,7 +1,10 @@
 const validate = async (result, ipfs) => {
   const uploadedFiles = window.uploadedFiles || false
+  const expectedResult = []
 
-  const expectedResult = await ipfs.add(window.uploadedFiles)
+  for await (const result of ipfs.add(window.uploadedFiles)) {
+    expectedResult.push(result)
+  }
 
   if (!result) {
     return {
@@ -48,7 +51,12 @@ const validate = async (result, ipfs) => {
 
 const code = `/* global ipfs */
 const run = async (files) => {
-  const result = // Place your code to add a file or files here
+  const result = []
+
+  for await (const resultPart of ) {
+    // Place your code to add a file or files on the for await of loop statement above
+    result.push(resultPart)
+  }
 
   return result
 }
@@ -57,7 +65,11 @@ return run
 
 const solution = `/* global ipfs */
 const run = async (files) => {
-  const result = await ipfs.add(files)
+  const result = []
+
+  for await (const resultPart of ipfs.add(files)) {
+    result.push(resultPart)
+  }
 
   return result
 }


### PR DESCRIPTION
First option for dealing with the new js ipfs api that always returns iterables.
This first approach adds a `for await...of` loop.

<img width="386" alt="Screen Shot 2020-02-17 at 7 04 37 PM" src="https://user-images.githubusercontent.com/2353186/74666476-000fef80-51bb-11ea-8320-d18d058247f3.png">

- Still working out how to solve the linting warnings on the monaco editor
- Although it looks a bit convoluted, it might be a better choice if we don't want to introduce a module when teaching

See original WIP PR: #381 