### PR TITLE
Use mode: history on the vue-router by using a SPA hack for Github Pages

### DIFF
--- a/DEVELOPING_TUTORIALS.md
+++ b/DEVELOPING_TUTORIALS.md
@@ -92,7 +92,7 @@ If proofing a PR for someone else, check out their branch (you'll see its name l
 > npm run serve
 ```
 
-6. Open a web browser to the following address to preview your work: http://localhost:3000/#/
+6. Open a web browser to the following address to preview your work: http://localhost:3000/
 
 Vue will update your localhost preview automatically as you make changes. However, you won't be able to see any newly added lessons until you've updated the appropriate routes and import statements, as described below.
 
@@ -170,13 +170,13 @@ If you want to add images to your Markdown file, place them in the `public/tutor
 Then in your lesson Markdown file, you can either add it with regular Markdown:
 
 ```
-![Description of the image](tutorial-assets/T0001L01-diagram.svg)
+![Description of the image](/tutorial-assets/T0001L01-diagram.svg)
 ```
 
 ...or with regular HTML, if you need to set the image size:
 
 ```html
-<img src="tutorial-assets/T0001L01-diagram.svg" width="300px" height="150px" />
+<img src="/tutorial-assets/T0001L01-diagram.svg" width="300px" height="150px" />
 ```
 
 ##### JavaScript file (skip for text-only lessons)
@@ -503,7 +503,7 @@ The `title` of your tutorial will be seen in course listings on our tutorials pa
 
 ![screenshot](public/title-in-featured-tutorials.png)
 
-The `url` will appear in the URL of your tutorial landing page and lessons. For example,  `http://proto.school/#/short-tutorial-title/01`. In most cases this will match your tutorial title, but you may find that you need to make it shorter. Note that this URL will also be used to create the abbreviated title that is shown in the breadcrumb navigation and the small header at the top of each page of your tutorial.
+The `url` will appear in the URL of your tutorial landing page and lessons. For example,  `http://proto.school/short-tutorial-title/01`. In most cases this will match your tutorial title, but you may find that you need to make it shorter. Note that this URL will also be used to create the abbreviated title that is shown in the breadcrumb navigation and the small header at the top of each page of your tutorial.
 
 ![screenshot](public/url-breadcrumb-header.png)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Clone the repo, install dependencies, check out the appropriate branch, and run 
 > npm run serve
 ```
 
-View the site on localhost at: http://localhost:3000/#/
+View the site on localhost at: http://localhost:3000/
 
 ## License
 

--- a/cypress/integration/tutorials.spec.js
+++ b/cypress/integration/tutorials.spec.js
@@ -29,14 +29,14 @@ function viewSolutionsAndSubmitAll (tutorialId) {
   const lessonCount = tutorials[tutorialId].lessons.length // count excludes resources page
   // const hasResources = tutorials[tutorialId].hasOwnProperty('resources')
   it(`should find the ${tutorialName} tutorial`, function () {
-    cy.visit(`/#/${tutorialName}/`)
-    cy.get(`[href="#/${tutorialName}/01"]`).click()
+    cy.visit(`/${tutorialName}/`)
+    cy.get(`[href="/${tutorialName}/01"]`).click()
   })
   // loop through standard lessons and attempt to pass challenges
   for (let i = 1; i <= lessonCount; i++) {
     let lessonNr = i.toString().padStart(2, 0)
     it(`should view the solution and pass test ${lessonNr}`, function () {
-      cy.url().should('include', `#/${tutorialName}/${lessonNr}`)
+      cy.url().should('include', `/${tutorialName}/${lessonNr}`)
       cy.get('[data-cy=code-editor-ready]').should('be.visible') // wait for editor to be updated
       cy.get('[data-cy=view-solution]').click()
       cy.get('[data-cy=solution-editor-ready]').should('be.visible') // wait for editor to be updated
@@ -49,7 +49,7 @@ function viewSolutionsAndSubmitAll (tutorialId) {
     cy.contains('h1', 'Resources') // loads resources page
     cy.get('[data-cy=resources-content]') // loads meaningful content
     cy.get('[data-cy=more-tutorials]').click()
-    cy.url().should('include', `#/tutorials/`)
+    cy.url().should('include', `/tutorials/`)
   })
 }
 
@@ -59,7 +59,7 @@ function renderAllLessonsInTutorial (tutorialId) {
   const standardLessonCount = standardLessons.length
 
   it(`should find ${tutorialName} landing page with correct lesson count`, function () {
-    cy.visit(`/#/${tutorialName}/`)
+    cy.visit(`/${tutorialName}/`)
     cy.get(`[data-cy=lesson-link]`).should('have.length', standardLessonCount)
   })
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -22,4 +22,12 @@
 //
 //
 // -- This is will overwrite an existing command --
-// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+  originalFn(url, { ...options, failOnStatusCode: false })
+})
+
+Cypress.on('uncaught:exception', (error, runnable) => {
+  console.error(error)
+
+  return false
+})

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+
+  <title>ProtoSchool</title>
+
+  <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // https://github.com/rafrex/spa-github-pages
+      // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
+      // ----------------------------------------------------------------------
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. http://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // http://www.foo.tld/?p=/one/two&q=a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+      var segmentCount = 0;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + segmentCount).join('/') + '/?p=/' +
+        l.pathname.slice(1).split('/').slice(segmentCount).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&q=' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+
+    </script>
+</head>
+
+<body>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</body>
+
+
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,35 @@
         font-family: 'Roboto', sans-serif;
       }
     </style>
+    <script type="text/javascript">
+        // Single Page Apps for GitHub Pages
+        // https://github.com/rafrex/spa-github-pages
+        // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
+        // ----------------------------------------------------------------------
+        // This script checks to see if a redirect is present in the query string
+        // and converts it back into the correct url and adds it to the
+        // browser's history using window.history.replaceState(...),
+        // which won't cause the browser to attempt to load the new url.
+        // When the single page app is loaded further down in this file,
+        // the correct url will be waiting in the browser's history for
+        // the single page app to route accordingly.
+        (function(l) {
+          if (l.search) {
+            var q = {};
+            l.search.slice(1).split('&').forEach(function(v) {
+              var a = v.split('=');
+              q[a[0]] = a.slice(1).join('=').replace(/~and~/g, '&');
+            });
+            if (q.p !== undefined) {
+              window.history.replaceState(null, null,
+                l.pathname.slice(0, -1) + (q.p || '') +
+                (q.q ? ('?' + q.q) : '') +
+                l.hash
+              );
+            }
+          }
+        }(window.location))
+    </script>
   </head>
   <body>
     <noscript>

--- a/src/components/CodeEditor.vue
+++ b/src/components/CodeEditor.vue
@@ -10,7 +10,7 @@
       <span v-if="cachedCode" @click="resetCode" class="textLink" data-cy="reset-code">Reset Code</span>
       <MonacoEditor
         class="editor mt2"
-        srcPath="."
+        srcPath=""
         :height="editorHeight"
         :options="options"
         :code="code"
@@ -29,7 +29,7 @@
       <MonacoEditor
         v-show="viewSolution"
         class="editor"
-        srcPath="."
+        srcPath=""
         :height="editorHeight"
         :options="Object.assign({}, { readOnly: true }, options)"
         :code="solution"

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -6,7 +6,7 @@
       <div v-if="tutorial" class="link-list flex overflow-auto items-center bg-aqua navy f5 fw6 center tc mw7">
         <router-link class="nav-link navy" to="/tutorials">Tutorials</router-link>
         <span class="fw4">></span>
-        <router-link data-cy="tutorial-landing-link" class="nav-link navy" :to="tutorialLanding">{{tutorial.shortTitle}}</router-link>
+        <router-link data-cy="tutorial-landing-link" class="nav-link navy" :to="tutorialUrl">{{tutorial.shortTitle}}</router-link>
       </div>
       <!-- standard nav  -->
       <div v-else class="link-list dn flex overflow-auto items-center bg-aqua white tc mw7">
@@ -26,7 +26,7 @@
         <div v-if="tutorial" class="flex-auto link fw5 f5 db bb border-aqua navy">
           <router-link class="nav-link navy" to="/tutorials">Tutorials</router-link>
           <span class="fw4"> > </span>
-          <router-link class="nav-link navy" :to="tutorialLanding">{{tutorial.shortTitle}}</router-link>
+          <router-link class="nav-link navy" :to="tutorialUrl">{{tutorial.shortTitle}}</router-link>
         </div>
         <!-- standard nav  -->
         <div v-else class="flex-auto link fw6 f5 db bb border-aqua">{{currentPage}}</div>
@@ -56,7 +56,6 @@ export default {
     return {
       isHamburgerClosed: true,
       currentPath: self.$route.path.toString(),
-      tutorialLanding: '/' + self.$route.path.split('/')[1],
       links: [
         { text: 'Home', path: '/' },
         { text: 'Tutorials', path: '/tutorials' },
@@ -74,6 +73,9 @@ export default {
       }
 
       return getTutorialByUrl(this.$route.params.tutorialUrl)
+    },
+    tutorialUrl: function () {
+      return `/${this.tutorial.url}`
     },
     currentPage: function () {
       let pageName

--- a/src/router.js
+++ b/src/router.js
@@ -80,6 +80,7 @@ const routes = [
 migrateCache()
 
 const router = new VueRouter({
+  mode: 'history',
   routes,
   scrollBehavior (to, from) {
     return { x: 0, y: 0 }
@@ -89,7 +90,7 @@ const router = new VueRouter({
 // track page view via Countly when route changes
 router.afterEach((to) => {
   if (!window.Countly) return
-  window.Countly.q.push(['track_pageview', '/#' + to.path])
+  window.Countly.q.push(['track_pageview', '/' + to.path])
 })
 
 export default router

--- a/src/static/tutorials.json
+++ b/src/static/tutorials.json
@@ -50,13 +50,13 @@
 			},
 			{
 				"title": "IPFS: Mutable File System (MFS)",
-				"link": "https://proto.school/#/mutable-file-system",
+				"link": "https://proto.school/mutable-file-system",
 				"type": "tutorial",
 				"description": "Explore the Mutable File System (MFS), which lets you work with files and directories in IPFS as if you were using a traditional name-based file system. (This tutorial includes JavaScript code challenges.)"
 			},
 			{
 				"title": "P2P Data Links with Content Addressing",
-				"link": "https://proto.school/#/basics/",
+				"link": "https://proto.school/basics/",
 				"type": "tutorial",
 				"description": "Use the IPFS DAG API to create create verifiable links between dataset with Content Identifiers (CIDs). (This tutorial includes JavaScript code challenges.)"
 			}
@@ -76,7 +76,7 @@
 			},
 			{
 				"title": "Blogging on the Decentralized Web",
-				"link": "https://proto.school/#/blog/",
+				"link": "https://proto.school/blog/",
 				"type": "tutorial",
 				"description": "Ready for a bigger challenge with the IPFS DAG API? Use CIDs to build and update a complex web of data."
 			},
@@ -94,7 +94,7 @@
 			},
 			{
 				"title": "IPFS: Regular Files API",
-				"link": "https://proto.school/#/regular-files-api",
+				"link": "https://proto.school/regular-files-api",
 				"type": "tutorial",
 				"description": "Ready to deal with more than primitives? Explore the API custom-built for efficient handling of files in IPFS."
 			}
@@ -126,7 +126,7 @@
 			},
 			{
 				"title": "IPFS: Regular Files API",
-				"link": "https://proto.school/#/regular-files-api",
+				"link": "https://proto.school/regular-files-api",
 				"type": "tutorial",
 				"description": "Ready to deal with more than primitives? Explore the API custom-built for efficient handling of files in IPFS."
 			}
@@ -159,7 +159,7 @@
 			},
 			{
 				"title": "IPFS: Regular Files API",
-				"link": "https://proto.school/#/regular-files-api",
+				"link": "https://proto.school/regular-files-api",
 				"type": "tutorial",
 				"description": "Explore the other half of the IPFS Files API, where you'll add and retrieve files and read their contents without the abstraction layer of the Mutable File System."
 			},
@@ -177,7 +177,7 @@
 			},
 			{
 				"title": "P2P Data Links with Content Addressing",
-				"link": "https://proto.school/#/basics/",
+				"link": "https://proto.school/basics/",
 				"type": "tutorial",
 				"description": "You've seen the IPFS Files API. Now explore the IPFS DAG API, where you'll use CIDs to create verifiable links between datasets."
 			}
@@ -210,13 +210,13 @@
 			},
 			{
 				"title": "IPFS: Mutable File System (MFS)",
-				"link": "https://proto.school/#/mutable-file-system",
+				"link": "https://proto.school/mutable-file-system",
 				"type": "tutorial",
 				"description": "Wish adding files to IPFS felt more like using a traditional name-based file system? Explore the Mutable File System (MFS)."
 			},
 			{
 				"title": "P2P Data Links with Content Addressing",
-				"link": "https://proto.school/#/basics/",
+				"link": "https://proto.school/basics/",
 				"type": "tutorial",
 				"description": "You've seen the IPFS Files API. Now explore the IPFS DAG API, where you'll use CIDs to create verifiable links between datasets."
 			}

--- a/src/tutorials/0001-data-structures/05.md
+++ b/src/tutorials/0001-data-structures/05.md
@@ -54,7 +54,7 @@ these data structures backwards, from the leaf nodes on up to the root node.
 
 ## Directed Acyclic Graphs (DAG)
 
-![Directed Acycil Graphs](tutorial-assets/T0001L01-dag.svg)
+![Directed Acycil Graphs](/tutorial-assets/T0001L01-dag.svg)
 
 DAG is an acronym for [`Directed Acyclic Graph`](https://en.wikipedia.org/wiki/Directed_acyclic_graph). It's a fancy way of describing a
 specific kind of Merkle tree (hash tree) where different branches in the tree can point at other branches

--- a/src/tutorials/0003-blog/01.md
+++ b/src/tutorials/0003-blog/01.md
@@ -3,7 +3,7 @@
     type: "code"
 ---
 
-In the [Basics tutorial](#/basics/02), we learned that a link in IPFS is represented as an instance of `CID`:
+In the [Basics tutorial](/basics/02), we learned that a link in IPFS is represented as an instance of `CID`:
 
 ```javascript
 {

--- a/src/tutorials/0004-mutable-file-system/01.md
+++ b/src/tutorials/0004-mutable-file-system/01.md
@@ -7,7 +7,7 @@
 
 [IPFS](https://ipfs.io/), or the InterPlanetary File System, is a peer-to-peer (P2P) networking protocol used to share data on the distributed web. As its full name suggests, you can think of IPFS as a file system, and it has some unique characteristics that make it ideal for safe, decentralized sharing.
 
-If you haven't yet done so, we encourage you to check out our [Decentralized Data Structures tutorial](https://proto.school/#/data-structures/), where you can learn all about the decentralized web and how it compares to the web you're accustomed to. There you'll learn all about content addressing, cryptographic hashing, Content Identifiers (CIDs), and sharing with peers, all of which you'll need to understand to make the most of this tutorial on IPFS.
+If you haven't yet done so, we encourage you to check out our [Decentralized Data Structures tutorial](https://proto.school/data-structures/), where you can learn all about the decentralized web and how it compares to the web you're accustomed to. There you'll learn all about content addressing, cryptographic hashing, Content Identifiers (CIDs), and sharing with peers, all of which you'll need to understand to make the most of this tutorial on IPFS.
 
 ## Storing and sharing data in IPFS
 

--- a/src/tutorials/0004-mutable-file-system/06.md
+++ b/src/tutorials/0004-mutable-file-system/06.md
@@ -3,7 +3,7 @@
     type: "file-upload"
 ---
 
-As you learned in the [Decentralized Data Structures tutorial](https://proto.school/#/data-structures), CIDs (Content Identifiers) are uniquely matched to the content they represent through cryptographic hashing. Two files with identical contents have identical CIDs (hashes) and two files with even the smallest difference between them have distinct CIDs. The same is true for directories. Every time you update the contents of a file or directory, its CID changes.
+As you learned in the [Decentralized Data Structures tutorial](https://proto.school/data-structures), CIDs (Content Identifiers) are uniquely matched to the content they represent through cryptographic hashing. Two files with identical contents have identical CIDs (hashes) and two files with even the smallest difference between them have distinct CIDs. The same is true for directories. Every time you update the contents of a file or directory, its CID changes.
 
 When your root directory was empty and you checked its status using [`ipfs.files.stat`](https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/FILES.md#filesstat), you saw this result:
 

--- a/src/tutorials/0005-regular-files-api/01.md
+++ b/src/tutorials/0005-regular-files-api/01.md
@@ -7,11 +7,11 @@
 
 [IPFS](https://ipfs.io/) is a peer-to-peer (P2P) networking protocol used to share data on the distributed web. You can think of it as a file system with some unique characteristics that make it ideal for safe, decentralized sharing.
 
-If you haven't yet done so, we encourage you to check out our [Decentralized Data Structures](https://proto.school/#/data-structures/) tutorial to learn all about the decentralized web and how it compares to the web you're accustomed to. There you'll learn all about content addressing, cryptographic hashing, Content Identifiers (CIDs), and sharing with peers, all of which you'll need to understand to make the most of this tutorial.
+If you haven't yet done so, we encourage you to check out our [Decentralized Data Structures](https://proto.school/data-structures/) tutorial to learn all about the decentralized web and how it compares to the web you're accustomed to. There you'll learn all about content addressing, cryptographic hashing, Content Identifiers (CIDs), and sharing with peers, all of which you'll need to understand to make the most of this tutorial.
 
 ## The Files API vs the DAG API
 
-You can store multiple types of data with IPFS. If you've explored our [P2P Data Links with Content Addressing](https://proto.school/#/basics) or [Blogging on the Decentralized Web](https://proto.school/#/blog) tutorial, you've already seen how you can store primitives, objects and arrays on the network using the DAG API.
+You can store multiple types of data with IPFS. If you've explored our [P2P Data Links with Content Addressing](https://proto.school/basics) or [Blogging on the Decentralized Web](https://proto.school/blog) tutorial, you've already seen how you can store primitives, objects and arrays on the network using the DAG API.
 
 The DAG API allows you to use the unique and versatile primitive data structures offered by [IPLD](https://github.com/ipld/ipld) (InterPlanetary Linked Data) within IPFS. You can recognize its methods in js-ipfs (the JavaScript implementation of IPFS) because they take the following format: `ipfs.dag.someMethod()`
 
@@ -21,7 +21,7 @@ The Files API, on the other hand, is custom-built for a more specific use case. 
 
 ## The Regular Files API vs the MFS Files API
 
-If you've read our [Mutable File System tutorial](https://proto.school/#/mutable-file-system), you may be thinking, "I've already learned how to work with files on IPFS. How will this be any different?"
+If you've read our [Mutable File System tutorial](https://proto.school/mutable-file-system), you may be thinking, "I've already learned how to work with files on IPFS. How will this be any different?"
 
 The Mutable File System (MFS) provides an API designed to replicate familiar file system operations such as `mkdir`, `ls`, `cp`, and others, mimicking the way you organize files and directories on a computer. However, the way that content is addressed in IPFS makes it an immutable file system. The address to a file or directory depends on its contents, so any change to a file or directory will result in an entirely new address. The MFS Files API works on a familiar-looking file system with regular paths — like `/some/stuff` — in the local IPFS node, which hides the complexity of immutable content addressing.
 

--- a/src/tutorials/0005-regular-files-api/03.md
+++ b/src/tutorials/0005-regular-files-api/03.md
@@ -46,6 +46,6 @@ The result of this `Promise` is an array of objects, one for each file added to 
 }
 ```
 
-The value of the `hash` is a CID (Content Identifier), a unique address generated from the content of the node. (For a more in-depth look at how CIDs are generated and why they're important, check out our [Decentralized data structures](https://proto.school/#/data-structures) tutorial.) In a future lesson, we will learn how to use this value to retrieve the contents of a file.
+The value of the `hash` is a CID (Content Identifier), a unique address generated from the content of the node. (For a more in-depth look at how CIDs are generated and why they're important, check out our [Decentralized data structures](https://proto.school/data-structures) tutorial.) In a future lesson, we will learn how to use this value to retrieve the contents of a file.
 
 The `add` method accepts other `data` formats besides the `File` object and offers many advanced `options` for setting your chunk size and hashing algorithm, pinning files as they're added, and more. We're highlighting the basics in this tutorial, but you can check out the [full documentation](https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/FILES.md#add) to learn more.

--- a/src/tutorials/0005-regular-files-api/04.md
+++ b/src/tutorials/0005-regular-files-api/04.md
@@ -3,7 +3,7 @@
     type: "code"
 ---
 
-In the previous lesson, you saw that each file added to IPFS has its own unique `hash` derived from its content. This `hash`, also known as a [CID (Content Identifier)](https://proto.school/#/data-structures/04), can be used like an address to access the file. If you know a file's CID, you can use the `cat` method provided by the Regular IPFS Files API -- similar to the one you may have seen previously in Unix-style systems -- to retrieve its contents like so:
+In the previous lesson, you saw that each file added to IPFS has its own unique `hash` derived from its content. This `hash`, also known as a [CID (Content Identifier)](https://proto.school/data-structures/04), can be used like an address to access the file. If you know a file's CID, you can use the `cat` method provided by the Regular IPFS Files API -- similar to the one you may have seen previously in Unix-style systems -- to retrieve its contents like so:
 
 ```javascript
 await ipfs.cat(ipfsPath, [options])

--- a/src/tutorials/0005-regular-files-api/05.md
+++ b/src/tutorials/0005-regular-files-api/05.md
@@ -64,7 +64,7 @@ In this case we'd end up with six objects in our resulting array: one for each o
 
 It's important to note that directories we create in this way do not behave as in a regular file system. If we've wrapped some files with a directory with using `add`, we can't simply `add` new files to that directory. The contents of the directory we just created are final and immutable.
 
-This is because of the way in which IPFS uses [content addressing](https://proto.school/#/data-structures/03): different contents lead to a different cryptograhpic hash (Content Identifier), whether we're working with directories or files themselves.
+This is because of the way in which IPFS uses [content addressing](https://proto.school/data-structures/03): different contents lead to a different cryptograhpic hash (Content Identifier), whether we're working with directories or files themselves.
 
 But what if you forgot to add a file to a directory you just created? You'll have to call the `add` method again with all the files you want wrapped with that directory, resulting in a new directory altogether with a new CID.
 
@@ -73,4 +73,4 @@ However, it's important to note that the file won't actually be stored multiple 
 **Rather than thinking of directories created with `{ wrapWithDirectory: true }` as traditional file folders, it's more useful to think of them as naming shortcuts, as we'll see in upcoming lessons.**
 
 ## An alternative
-If you're looking for an experience that better mimics a traditional file system, you should explore the [Mutable File System (MFS)](https://proto.school/#/mutable-file-system), a tool built into IPFS that lets you treat files like you normally would in a name-based filesystem — you can add, remove, move, and edit MFS files and have all the work of updating links and hashes taken care of for you. It's an abstraction that lets you deal with immutable data as if it were mutable.
+If you're looking for an experience that better mimics a traditional file system, you should explore the [Mutable File System (MFS)](https://proto.school/mutable-file-system), a tool built into IPFS that lets you treat files like you normally would in a name-based filesystem — you can add, remove, move, and edit MFS files and have all the work of updating links and hashes taken care of for you. It's an abstraction that lets you deal with immutable data as if it were mutable.

--- a/src/tutorials/0005-regular-files-api/07.md
+++ b/src/tutorials/0005-regular-files-api/07.md
@@ -5,7 +5,7 @@
 
 So far, we've used the CID of the file or directory as the path when accessing a file. However, now that we've learned we can wrap a number of files into a directory, we have a new way to address a file.
 
-As you saw in our lesson on the [`wrapWithDirectory` option](https://proto.school/#/file-api/05), we can add one or more files to a new directory and, when doing so, we need to provide a name to each one of the files we add. As a result, the `add` method call returns us an array which contains the `hash` value (CID) for each of the files and directories created.
+As you saw in our lesson on the [`wrapWithDirectory` option](https://proto.school/file-api/05), we can add one or more files to a new directory and, when doing so, we need to provide a name to each one of the files we add. As a result, the `add` method call returns us an array which contains the `hash` value (CID) for each of the files and directories created.
 
 As mentioned earlier, it's useful to think of directories created with `{ wrapWithDirectory: true }` as naming shortcuts, rather than as traditional file folders. Here's why:
 

--- a/src/utils/tutorials.js
+++ b/src/utils/tutorials.js
@@ -67,7 +67,7 @@ export function getLesson (tutorialId, lessonId) {
 
 // returns URL for tutorial's landing page
 export function getTutorialFullUrl (tutorialId) {
-  return `${window.location.origin}/#/${tutorials[tutorialId].url}`
+  return `${window.location.origin}/${tutorials[tutorialId].url}`
 }
 
 // returns boolean - true if user has passed all lessons in the tutorial

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,7 +1,7 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 module.exports = {
-  publicPath: './',
+  publicPath: '/',
   devServer: {
     port: 3000,
     disableHostCheck: true


### PR DESCRIPTION
This PR implements a hack that enables non-hashing routing to github-pages-powered websites. It's working locally in dev and production mode.

Hack can be found here: https://github.com/rafrex/spa-github-pages

SEO Note from the repo:

> A quick SEO note - while it's never good to have a 404 response, it appears based on Search Engine Land's testing that Google's crawler will treat the JavaScript window.location redirect in the 404.html file the same as a 301 redirect for its indexing. From my testing I can confirm that Google will index all pages without issue, the only caveat is that the redirect query is what Google indexes as the url. For example, the url example.tld/about will get indexed as example.tld/?p=/about. When the user clicks on the search result, the url will change back to example.tld/about once the site loads.

closes #388, #105 
Will enable us to start working on: #258