### PR TITLE
fix: redirect any github 404 to our custom 404 page

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+
+  <title>ProtoSchool</title>
+
+  <script type="text/javascript">
+      window.location.replace('https://proto.school/#/404')
+    </script>
+</head>
+
+<body>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</body>
+
+
+</html>

--- a/public/404.html
+++ b/public/404.html
@@ -7,7 +7,7 @@
   <title>ProtoSchool</title>
 
   <script type="text/javascript">
-      window.location.replace('https://proto.school/#/404')
+      window.location.replace(`${window.location.origin}/#/404`)
     </script>
 </head>
 


### PR DESCRIPTION
Closes #388 

This should fix the 404 gibhub page showing.
@terichadbourne what we discussed regarding redirecting valid urls to hash urls would be a bit more tricky (e.g. `/tutorials` -> `/#/tutorials`) since it would still rely on the 404 hack #393 