### PR TITLE
fix(content): clarify sample CID in  anatomy-of-a-cid

### DIFF
--- a/src/tutorials/0006-anatomy-of-a-cid/01.md
+++ b/src/tutorials/0006-anatomy-of-a-cid/01.md
@@ -9,7 +9,7 @@ The [CID specification](https://github.com/multiformats/cid), which originated i
 
 A content identifier, or **CID**, is a self-describing content-addressed identifier. It doesn't indicate _where_ content is stored, but it forms a kind of address based on the content itself. The number of characters in a CID depends on the **cryptographic hash** of the underlying content, rather than the size of the content itself. As most content in IPFS is hashed using `sha2-256`, most CIDs you encounter there will be the same size (256 bits, which equates to 32 bytes). This makes them much easier to manage, especially when dealing with multiple pieces of content.
 
-For example, if we stored a Wikipedia page on aardvarks on the IPFS network, its CID would look like this:  [`QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco`](https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/Aardvark.html)
+For example, when we link to a Wikipedia page on aardvarks on the IPFS network, the CID of the entire Wikipedia snapshot looks like this:  [`QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco`](https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/Aardvark.html)
 
 The first step to creating a CID is to transform the input data, using a **cryptographic algorithm** that maps input of arbitrary size (data or a file) to output of a fixed size. This transformation is known as **cryptographic hash digest** or simply **hash**.
 
@@ -22,6 +22,6 @@ The **cryptographic algorithm** used must generate hashes that have the followin
 - **One-way**: It should be infeasible to reconstruct the data from the hash.
 - **Unique**: Only one file can produce one specific hash.
 
-Note that if we change a single word in our documentation on aardvarks, our cryptographic algorithm will generate a completely different hash for the article. When we fetch data using a content address, we're guaranteed to see the intended version of that data. This is quite different from location addressing on the centralized web, where the content at a given address (URL) can change over time.
+Note that if we change a single word in our documentation on aardvarks, our cryptographic algorithm will generate a completely different hash for the entire Wikipedia snapshot. When we fetch data using a content address, we're guaranteed to see the intended version of that data. This is quite different from location addressing on the centralized web, where the content at a given address (URL) can change over time.
 
 Cryptographic hashing is not unique to IPFS, and there are many hashing algorithms out there like `sha2-256`, `blake2b`, `sha3-256` and `sha3-512`, the **no-longer-secure** `sha1` and `md5`, etc. IPFS uses **`sha2-256`** by default, though a CID supports virtually any strong cryptographic hash algorithm.


### PR DESCRIPTION
I really enjoyed this tutorial, thank you for creating it! :heart: 

This PR applies a small correction to `tutorials/0006-anatomy-of-a-cid`.

The key takeaway here is to be explicit that the sample  CID is of the entire Wikipedia snapshot, not just that one sub-article. In the old version reader could think it is a CID of the single article.


Feel free to rewrite it if my English sounds wonky :-)

ps. If Wikipedia example is too complex, we could replace it with a standalone picture of aardvarks, and use its direct CID. 
