### PR TITLE
fix(content): use an image instead of a website for the CID examples

### DIFF
--- a/src/tutorials/0006-anatomy-of-a-cid/01.md
+++ b/src/tutorials/0006-anatomy-of-a-cid/01.md
@@ -9,7 +9,7 @@ The [CID specification](https://github.com/multiformats/cid), which originated i
 
 A content identifier, or **CID**, is a self-describing content-addressed identifier. It doesn't indicate _where_ content is stored, but it forms a kind of address based on the content itself. The number of characters in a CID depends on the **cryptographic hash** of the underlying content, rather than the size of the content itself. As most content in IPFS is hashed using `sha2-256`, most CIDs you encounter there will be the same size (256 bits, which equates to 32 bytes). This makes them much easier to manage, especially when dealing with multiple pieces of content.
 
-For example, if we stored a Wikipedia page on aardvarks on the IPFS network, its CID would look like this:  [`QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco`](https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/Aardvark.html)
+For example, if we stored an image of an aardvark on the IPFS network, its CID would look like this:  [`QmcRD4wkPPi6dig81r5sLj9Zm1gDCL4zgpEj9CfuRrGbzF`](https://ipfs.io/ipfs/QmcRD4wkPPi6dig81r5sLj9Zm1gDCL4zgpEj9CfuRrGbzF)
 
 The first step to creating a CID is to transform the input data, using a **cryptographic algorithm** that maps input of arbitrary size (data or a file) to output of a fixed size. This transformation is known as **cryptographic hash digest** or simply **hash**.
 
@@ -22,6 +22,6 @@ The **cryptographic algorithm** used must generate hashes that have the followin
 - **One-way**: It should be infeasible to reconstruct the data from the hash.
 - **Unique**: Only one file can produce one specific hash.
 
-Note that if we change a single word in our documentation on aardvarks, our cryptographic algorithm will generate a completely different hash for the article. When we fetch data using a content address, we're guaranteed to see the intended version of that data. This is quite different from location addressing on the centralized web, where the content at a given address (URL) can change over time.
+Note that if we change a single pixel in our aardvark image, our cryptographic algorithm will generate a completely different hash for the article. When we fetch data using a content address, we're guaranteed to see the intended version of that data. This is quite different from location addressing on the centralized web, where the content at a given address (URL) can change over time.
 
 Cryptographic hashing is not unique to IPFS, and there are many hashing algorithms out there like `sha2-256`, `blake2b`, `sha3-256` and `sha3-512`, the **no-longer-secure** `sha1` and `md5`, etc. IPFS uses **`sha2-256`** by default, though a CID supports virtually any strong cryptographic hash algorithm.

--- a/src/tutorials/0006-anatomy-of-a-cid/01.md
+++ b/src/tutorials/0006-anatomy-of-a-cid/01.md
@@ -22,6 +22,6 @@ The **cryptographic algorithm** used must generate hashes that have the followin
 - **One-way**: It should be infeasible to reconstruct the data from the hash.
 - **Unique**: Only one file can produce one specific hash.
 
-Note that if we change a single pixel in our aardvark image, our cryptographic algorithm will generate a completely different hash for the article. When we fetch data using a content address, we're guaranteed to see the intended version of that data. This is quite different from location addressing on the centralized web, where the content at a given address (URL) can change over time.
+Note that if we change a single pixel in our aardvark image, our cryptographic algorithm will generate a completely different hash for the image. When we fetch data using a content address, we're guaranteed to see the intended version of that data. This is quite different from location addressing on the centralized web, where the content at a given address (URL) can change over time.
 
 Cryptographic hashing is not unique to IPFS, and there are many hashing algorithms out there like `sha2-256`, `blake2b`, `sha3-256` and `sha3-512`, the **no-longer-secure** `sha1` and `md5`, etc. IPFS uses **`sha2-256`** by default, though a CID supports virtually any strong cryptographic hash algorithm.

--- a/src/tutorials/0006-anatomy-of-a-cid/05.md
+++ b/src/tutorials/0006-anatomy-of-a-cid/05.md
@@ -27,6 +27,6 @@ Let's examine two examples of CIDs in their string form:
 
 We know the first one is a `CIDv0` because it starts with `Qm...`. All hashes that start with `Qm` can safely be interpreted as `base58btc` as a CID of Version 0.
 
-The second example starts with `b`, the base encoding prefix indentifier for `base32`, which is used by default by most implementations of IPFS.
+The second example starts with `b`, the base encoding prefix identifier for `base32`, which is used by default by most implementations of IPFS.
 
 For the complete list of `multibase` identifiers, see [this table](https://github.com/multiformats/multibase/blob/master/multibase.csv).

--- a/src/tutorials/0006-anatomy-of-a-cid/06.md
+++ b/src/tutorials/0006-anatomy-of-a-cid/06.md
@@ -49,10 +49,10 @@ However, because `CIDv1` supports multiple codecs and multiple bases and `CIDv0`
 - `multihash-algorithm = sha2-256`
 - `multihash-length = 32` (32 bytes, equivalent to 256 bits)
 
-To test this theory, you can check out our beloved `Aardvark` page here, hosted on the IPFS network: https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/Aardvark.html
+To test this theory, you can check out our beloved `Aardvark` here, hosted on the IPFS network: https://ipfs.io/ipfs/QmcRD4wkPPi6dig81r5sLj9Zm1gDCL4zgpEj9CfuRrGbzF
 
-- Open the link in your browser and copy the CID from the middle of the URL (`QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco`)
+- Open the link in your browser and copy the CID from the end of the URL (`QmcRD4wkPPi6dig81r5sLj9Zm1gDCL4zgpEj9CfuRrGbzF`)
 - In a new browser window, paste it into the [CID Inspector tool](https://cid.ipfs.io) and find the equivalent CIDv1 value displayed at the bottom of the screen
 - Back in your aardvark tab, replace the `v0` CID with the converted `v1` CID in the original URL and refresh the page
 
-You should see the same article on our aardvark.
+You should see the same image of our aardvark.

--- a/src/tutorials/0006-anatomy-of-a-cid/06.md
+++ b/src/tutorials/0006-anatomy-of-a-cid/06.md
@@ -49,7 +49,7 @@ However, because `CIDv1` supports multiple codecs and multiple bases and `CIDv0`
 - `multihash-algorithm = sha2-256`
 - `multihash-length = 32` (32 bytes, equivalent to 256 bits)
 
-To test this theory, you can check out our beloved `Aardvark` here, hosted on the IPFS network: https://ipfs.io/ipfs/QmcRD4wkPPi6dig81r5sLj9Zm1gDCL4zgpEj9CfuRrGbzF
+To test this theory, you can check out our beloved aardvark image here, hosted on the IPFS network: https://ipfs.io/ipfs/QmcRD4wkPPi6dig81r5sLj9Zm1gDCL4zgpEj9CfuRrGbzF
 
 - Open the link in your browser and copy the CID from the end of the URL (`QmcRD4wkPPi6dig81r5sLj9Zm1gDCL4zgpEj9CfuRrGbzF`)
 - In a new browser window, paste it into the [CID Inspector tool](https://cid.ipfs.io) and find the equivalent CIDv1 value displayed at the bottom of the screen


### PR DESCRIPTION
As pointed out by @lidel, referencing the wikipedia snapshot as an example, it might not be a good idea in the tutorial because it might cause confusion about what the CID refers to (entire wikipedia snapshot or just that single wikipedia article).

To circumvent this issue, it's just easier to have an image as the content instead of a whole website.

Closes #401 