### PR TITLE
docs: fix typos

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -73,7 +73,7 @@ members of the project's leadership.
 Please note that the organizers of each local ProtoSchool [event](https://proto.school/#/events)
 maintain their own Code of Conduct with additional guidance for local events and
 any related websites or repositories. To report instances of abusive, harassing, or
-otherwise unacceptable behavior that have occured within local events or repos,
+otherwise unacceptable behavior that have occurred within local events or repos,
 please reach out to your local leadership team using the contact information
 provided in their CoC.
 

--- a/DESIGNING_TUTORIALS.md
+++ b/DESIGNING_TUTORIALS.md
@@ -96,7 +96,7 @@ We're currently focused on improving our platform and growing our curriculum on 
 ### Creating an effective learner experience
 
 #### Know your audience
-- Your tutorial should be aimed at a specific audience level, typically beginner and ocassionally intermediate given our current curriculum.
+- Your tutorial should be aimed at a specific audience level, typically beginner and occasionally intermediate given our current curriculum.
 - Do your users need to already be familiar with certain concepts before starting your tutorial? Use the first lesson as a place to set out your expectations, linking to other tutorials or beginner-friendly learning materials they should review before starting your tutorial.
 - Don't go into detail on advanced concepts in a tutorial aimed at beginners. If you think of a related, more advanced topic that users might be interested to learn more about, consider including an aside in your text with a link to where they can learn more.
 - Use the resources page at the end of your tutorial to suggest next steps for further learning, linking to specific tutorials, videos or articles that build on the concepts you've just taught.

--- a/DEVELOPING_TUTORIALS.md
+++ b/DEVELOPING_TUTORIALS.md
@@ -184,7 +184,7 @@ By keeping your server running, you can preview your new tutorial in a web brows
 
 Answer a few quick questions about your tutorial and the ProtoWizard will use your responses to set up both a directory for your tutorial (eg `src/tutorials/0007-my-new-tutorial`) and the necessary metadata (title, description, etc.) to display the tutorial on our website. When finished, the ProtoWizard will let you know where to go to preview your new tutorial in your web browser.
 
-While the ProtoWizard only supports the intial creation of this data, you can edit the details later in `src/static/tutorials.json`. If you need to do this, please read [Manage Your Tutorial's Metadata](#manage-your-tutorials-metadata) for more information.
+While the ProtoWizard only supports the initial creation of this data, you can edit the details later in `src/static/tutorials.json`. If you need to do this, please read [Manage Your Tutorial's Metadata](#manage-your-tutorials-metadata) for more information.
 
 **Lessons**
 
@@ -777,7 +777,7 @@ The properties exported from this file depend on the lesson type, as follows:
 
 ### `utils` module
 
-This module is a set of utils designed to be re-used accross the validation code of different tutorials.
+This module is a set of utils designed to be re-used across the validation code of different tutorials.
 
 #### `utils.format`
 

--- a/src/tutorials/0004-mutable-file-system/09.md
+++ b/src/tutorials/0004-mutable-file-system/09.md
@@ -3,7 +3,7 @@
     type: "file-upload"
 ---
 
-Unlike `files.mv`, which removes items from their source path when moving them to their designation path, the [`files.cp`](https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/FILES.md#filescp) method allows you to a copy a file or directory to a new location while also leaving it intact at its source.
+Unlike `files.mv`, which removes items from their source path when moving them to their destination path, the [`files.cp`](https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/FILES.md#filescp) method allows you to a copy a file or directory to a new location while also leaving it intact at its source.
 
 The method looks like this:
 ```js

--- a/src/tutorials/0004-mutable-file-system/09.md
+++ b/src/tutorials/0004-mutable-file-system/09.md
@@ -3,7 +3,7 @@
     type: "file-upload"
 ---
 
-Unlike `files.mv`, which removes items from their source path when moving them to their desination path, the [`files.cp`](https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/FILES.md#filescp) method allows you to a copy a file or directory to a new location while also leaving it intact at its source.
+Unlike `files.mv`, which removes items from their source path when moving them to their designation path, the [`files.cp`](https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/FILES.md#filescp) method allows you to a copy a file or directory to a new location while also leaving it intact at its source.
 
 The method looks like this:
 ```js

--- a/src/tutorials/0004-mutable-file-system/10.md
+++ b/src/tutorials/0004-mutable-file-system/10.md
@@ -13,7 +13,7 @@ ipfs.files.read(path, [options])
 
 The `path` provided is the path of the file to read, and it must point to a file rather than a directory.
 
-The `files.read` method returns an Async Iterable that iterates over the file's chunks of data, i.e. Buffers. In our case, we ultimately need to convert Buffers into strings using the method `toString()`. However, the chunks of data within a single file need to be reassembled (concatenated) before the conversion. The [`it-to-buffer`](https://www.npmjs.com/package/it-to-buffer) package can iterate over all of the chunks and put them back together for us. (We've made this package availabe to you in our challenges as `toBuffer`.)
+The `files.read` method returns an Async Iterable that iterates over the file's chunks of data, i.e. Buffers. In our case, we ultimately need to convert Buffers into strings using the method `toString()`. However, the chunks of data within a single file need to be reassembled (concatenated) before the conversion. The [`it-to-buffer`](https://www.npmjs.com/package/it-to-buffer) package can iterate over all of the chunks and put them back together for us. (We've made this package available to you in our challenges as `toBuffer`.)
 
 ```js
 // the toBuffer variable is globally available (just like ipfs)

--- a/src/tutorials/0006-anatomy-of-a-cid/02.md
+++ b/src/tutorials/0006-anatomy-of-a-cid/02.md
@@ -3,7 +3,7 @@
     type: "multiple-choice"
 ---
 
-Occassionally, a hashing algorithm may be proven to be insecure, meaning it no longer complies with the characteristics that we defined earlier. This has already happened with `sha1`. With time, other algorithms may prove to be insufficient for content addressing in IPFS and other distributed information systems. For this reason, and in order to support multiple cryptographic algorithms, **we need to be able to know which algorithm was used to generate the hash** of specific content.
+Occasionally, a hashing algorithm may be proven to be insecure, meaning it no longer complies with the characteristics that we defined earlier. This has already happened with `sha1`. With time, other algorithms may prove to be insufficient for content addressing in IPFS and other distributed information systems. For this reason, and in order to support multiple cryptographic algorithms, **we need to be able to know which algorithm was used to generate the hash** of specific content.
 
 ![What is the hashing algorithm used in a hash?](tutorial-assets/T0006L02-what-algo.jpg)
 


### PR DESCRIPTION
Hey,

This PR will fix : 

- 1 typo in `CODE_OF_CONDUCT.md`
- 1 typo in `DESIGNING_TUTORIALS.md`
- 2 typos in `DEVELOPING_TUTORIALS.md`
- 1 typo in `src/tutorials/0004-mutable-file-system/09.md`
- 1 typo in `src/tutorials/0004-mutable-file-system/10.md`
- 1 typo in `src/tutorials/0006-anatomy-of-a-cid/02.md`



Bye! :robot: