### PR TITLE
Fix: handle PRs from forks failing builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os:
+  - linux
+dist: xenial
 language: node_js
 node_js:
   - lts/*
@@ -26,11 +29,11 @@ notifications:
   email: false
 deploy:
   provider: pages
-  local-dir: dist
-  target-branch: master
-  skip-cleanup: true
-  github-token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
-  keep-history: true
+  local_dir: dist
+  target_branch: master
+  cleanup: true
+  token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+  keep_history: true
   fqdn: proto.school
   on:
     branch: code

--- a/package-lock.json
+++ b/package-lock.json
@@ -7138,9 +7138,9 @@
       "dev": true
     },
     "err-code": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-      "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "errno": {
       "version": "0.1.7",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "cids": "^0.7.1",
-    "err-code": "^2.0.0",
+    "err-code": "^2.0.3",
     "googleapis": "^47.0.0",
     "highlight.js": "^9.12.0",
     "inquirer": "^7.1.0",

--- a/scripts/commands/build-data/index.js
+++ b/scripts/commands/build-data/index.js
@@ -4,6 +4,22 @@
     - Google APIs for events data
  */
 
+let log = require('npmlog')
+
+const logGroup = 'build:data'
+
+process.on('uncaughtException', (error) => {
+  // We can't fail if the branch is code, because it could be the cron job
+  if (error.code === 'NO_CONFIG' && process.env.BRANCH !== 'code') {
+    log.error(logGroup, 'ERROR NO_CONFIG:', error.message)
+    log.warn(logGroup, 'Not enough config set. Skipping build-data script...')
+    process.exit(0)
+  }
+
+  log.error(logGroup, error.code ? `ERROR ${error.code}:` : '', error.message)
+  process.exit(1)
+})
+
 const run = require('../../modules/run')
 const eventsData = require('./events-data')
 const mailchimp = require('./mailchimp')

--- a/scripts/modules/googleapis/auth.js
+++ b/scripts/modules/googleapis/auth.js
@@ -6,7 +6,7 @@
 const { google } = require('googleapis')
 
 if (!process.env.GOOGLE_CLIENT_ID) {
-  throw new Error('No config available. Add a .env file or make all the config available through env variables. Please check the docs at https://github.com/ProtoSchool/protoschool.github.io/tree/feat/events/scripts')
+  throw new Error('No config available. Add a .env file or make all the config available through env variables. Please check the docs at https://github.com/ProtoSchool/protoschool.github.io/tree/code/scripts')
 }
 
 const credentials = {

--- a/scripts/modules/googleapis/auth.js
+++ b/scripts/modules/googleapis/auth.js
@@ -2,11 +2,15 @@
     Create auth object for connecting with the Google APIs.
     All required information will be ready from env vars.
  */
+const errorCode = require('err-code')
 
 const { google } = require('googleapis')
 
 if (!process.env.GOOGLE_CLIENT_ID) {
-  throw new Error('No config available. Add a .env file or make all the config available through env variables. Please check the docs at https://github.com/ProtoSchool/protoschool.github.io/tree/code/scripts')
+  throw errorCode(
+    new Error('No config available. Add a .env file or make all the config available through env variables. Please check the docs at https://github.com/ProtoSchool/protoschool.github.io/tree/code/scripts'),
+    'NO_CONFIG'
+  )
 }
 
 const credentials = {


### PR DESCRIPTION
If a build from a PR that is started from a forked project starts, travis does not allow the secure env vars to be used. See here: 

- Travis issues: [travis#701287172](https://travis-ci.org/github/ProtoSchool/protoschool.github.io/builds/701287172) [travis#701462759](https://travis-ci.org/github/ProtoSchool/protoschool.github.io/builds/701462759)
- this is because secure env vars are not available outside the repo
    - [travis-ci#1946](https://github.com/travis-ci/travis-ci/issues/1946)
    - [travis-ci#6611](https://github.com/travis-ci/travis-ci/issues/6611)


Documented here: [https://docs.travis-ci.com](https://docs.travis-ci.com/user/environment-variables/#defining-encrypted-variables-in-travisyml)

> Encrypted environment variables are not available to pull requests from forks due to the security risk of exposing such information to unknown code.

![image](https://user-images.githubusercontent.com/2353186/85721360-328da400-b6e9-11ea-9e43-00a4d3780802.png)

We need to still run the build process, but skip the data build scripts.
For this we added a env var to travis `BRANCH=code` that is only set in the `code` branch.

So the logic is as follows:

1. If no config was found
    - And no `BRANCH=code` env var is defined, we ignore the error and exit with code 0
    - If `BRANCH=code` env var is defined, we fail the script with exit code 1
2. If config was found, proceed normally (it's the cron job or a website publish)

Fixes #456 and #459 (will rebase them into `code` after we get this merged)