### PR TITLE
fix: force double quotes on multiple choice files

### DIFF
--- a/src/tutorials/0006-anatomy-of-a-cid/01.js
+++ b/src/tutorials/0006-anatomy-of-a-cid/01.js
@@ -1,20 +1,22 @@
-const question = 'What is the default cryptographic algorithm used by IPFS to generate CIDs?'
+/* eslint quotes: ["error", "double"]  */
+
+const question = "What is the default cryptographic algorithm used by IPFS to generate CIDs?"
 
 const choices = [
   {
-    answer: '`sha1`',
+    answer: "`sha1`",
     correct: false,
-    feedback: 'Try again.'
+    feedback: "Try again."
   },
   {
-    answer: '`sha2-256`',
+    answer: "`sha2-256`",
     correct: true,
-    feedback: 'That\'s correct!'
+    feedback: "That's correct!"
   },
   {
-    answer: 'It uses a combination of `sha1`, `sha2-256`, `sha3-256`, `sha3-512` and `shake-256`.',
+    answer: "It uses a combination of `sha1`, `sha2-256`, `sha3-256`, `sha3-512` and `shake-256`.",
     correct: false,
-    feedback: 'IPFS only uses one algorithm to generate a CID.'
+    feedback: "IPFS only uses one algorithm to generate a CID."
   }
 ]
 

--- a/src/tutorials/0006-anatomy-of-a-cid/02.js
+++ b/src/tutorials/0006-anatomy-of-a-cid/02.js
@@ -1,20 +1,22 @@
-const question = 'How do CIDs support multiple cryptographic algorithms?'
+/* eslint quotes: ["error", "double"]  */
+
+const question = "How do CIDs support multiple cryptographic algorithms?"
 
 const choices = [
   {
-    answer: 'The length of the hash tells us which cryptographic algorithm was used. If the length is 256 bits (32 bytes) then the algorithm used was `sha2-256`. If the length is 512 bits (64 bytes) then the algorithm used was `sha2-512`.',
+    answer: "The length of the hash tells us which cryptographic algorithm was used. If the length is 256 bits (32 bytes) then the algorithm used was `sha2-256`. If the length is 512 bits (64 bytes) then the algorithm used was `sha2-512`.",
     correct: false,
     feedback: "It's true that the length of a `sha2-256` hash is 256 bits (32 bytes), but this isn't enough information to tell us what hashing algorithm was used. Check the information above and try again."
   },
   {
-    answer: 'They prefix the hash with a unique identifier that flags which algorithm was used to generate the hash.',
+    answer: "They prefix the hash with a unique identifier that flags which algorithm was used to generate the hash.",
     correct: false,
-    feedback: 'You\'re almost there! There\'s something else that the hash gets prefixed with.'
+    feedback: "You're almost there! There's something else that the hash gets prefixed with."
   },
   {
-    answer: `They prefix the hash with a unique identifier that flags both the algorithm used to generate the hash and the length of the hash value.`,
+    answer: "They prefix the hash with a unique identifier that flags both the algorithm used to generate the hash and the length of the hash value.",
     correct: true,
-    feedback: 'That\'s right!'
+    feedback: "That's right!"
   }
 ]
 

--- a/src/tutorials/0006-anatomy-of-a-cid/03.js
+++ b/src/tutorials/0006-anatomy-of-a-cid/03.js
@@ -1,20 +1,22 @@
-const question = 'How can we identify the encoding method used on specific data when using CIDv1?'
+/* eslint quotes: ["error", "double"]  */
+
+const question = "How can we identify the encoding method used on specific data when using CIDv1?"
 
 const choices = [
   {
-    answer: 'CIDv1 includes a multicodec prefix that specifies which encoding method was used.',
+    answer: "CIDv1 includes a multicodec prefix that specifies which encoding method was used.",
     correct: true,
-    feedback: 'That\'s right!'
+    feedback: "That's right!"
   },
   {
-    answer: 'CIDv1 always uses `dag-pb` as its encoding method.',
+    answer: "CIDv1 always uses `dag-pb` as its encoding method.",
     correct: false,
-    feedback: 'Nope! The `dag-pb` codec is used commonly in IPFS and IPLD, but not all CIDs use it.'
+    feedback: "Nope! The `dag-pb` codec is used commonly in IPFS and IPLD, but not all CIDs use it."
   },
   {
-    answer: 'The codec used on CIDv1 is always `base58btc`.',
+    answer: "The codec used on CIDv1 is always `base58btc`.",
     correct: false,
-    feedback: 'Nope! CIDv0 always used `base58btc` to convert binary data to a string, but in CIDv1 we have a more flexible way to determine the encoding method used.'
+    feedback: "Nope! CIDv0 always used `base58btc` to convert binary data to a string, but in CIDv1 we have a more flexible way to determine the encoding method used."
   }
 ]
 

--- a/src/tutorials/0006-anatomy-of-a-cid/04.js
+++ b/src/tutorials/0006-anatomy-of-a-cid/04.js
@@ -1,20 +1,22 @@
-const question = 'Which version of CIDs include the actual version number of the CID?'
+/* eslint quotes: ["error", "double"]  */
+
+const question = "Which version of CIDs include the actual version number of the CID?"
 
 const choices = [
   {
-    answer: 'None. The version number is inferred by detecting whether the IPLD format multicodec is present.',
+    answer: "None. The version number is inferred by detecting whether the IPLD format multicodec is present.",
     correct: false,
-    feedback: 'It\'s true that CIDv0 doesn\'t have a multicodec, but CIDv1 _does_ have a version prefix.'
+    feedback: "It's true that CIDv0 doesn't have a multicodec, but CIDv1 _does_ have a version prefix."
   },
   {
-    answer: 'All CIDs contain the version prefix, otherwise there would be no way to determine which version was used.',
+    answer: "All CIDs contain the version prefix, otherwise there would be no way to determine which version was used.",
     correct: false,
-    feedback: 'Actually, CIDv0 only had a multihash, with no multicodec or version prefix.'
+    feedback: "Actually, CIDv0 only had a multihash, with no multicodec or version prefix."
   },
   {
-    answer: 'Only CIDv1 includes the version prefix, since CIDv0 didn\'t have that specification.',
+    answer: "Only CIDv1 includes the version prefix, since CIDv0 didn't have that specification.",
     correct: true,
-    feedback: 'That\'s correct!'
+    feedback: "That's correct!"
   }
 ]
 

--- a/src/tutorials/0006-anatomy-of-a-cid/05.js
+++ b/src/tutorials/0006-anatomy-of-a-cid/05.js
@@ -1,20 +1,22 @@
-const question = 'How can we determine the base encoding method used to represent a binary CID as a string?'
+/* eslint quotes: ["error", "double"]  */
+
+const question = "How can we determine the base encoding method used to represent a binary CID as a string?"
 
 const choices = [
   {
-    answer: 'We have to guess, but it\'s easy because most implementations of IPFS encode CIDs with `base32`.',
+    answer: "We have to guess, but it's easy because most implementations of IPFS encode CIDs with `base32`.",
     correct: false,
-    feedback: 'Most current implementations of IPFS use `base32`, but CIDv0 didn\'t. Is there a helpful clue in the string version of the CID?'
+    feedback: "Most current implementations of IPFS use `base32`, but CIDv0 didn't. Is there a helpful clue in the string version of the CID?"
   },
   {
-    answer: 'We can check the initial characters of the CID. If it starts with `Qm`, it\'s `base58btc`. If it starts with `b` it\'s `base32`. In both cases the CID version is `CIDv1`.',
+    answer: "We can check the initial characters of the CID. If it starts with `Qm`, it's `base58btc`. If it starts with `b` it's `base32`. In both cases the CID version is `CIDv1`.",
     correct: false,
-    feedback: 'Hmm, that first part is right, but are you sure both of those examples could be CIDv1?'
+    feedback: "Hmm, that first part is right, but are you sure both of those examples could be CIDv1?"
   },
   {
-    answer: 'We can check the initial characters of the CID. If it starts with `Qm`, it\'s `base58btc` and is `CIDv0`. If it starts with `b` it\'s `base32` and is `CIDv1`.',
+    answer: "We can check the initial characters of the CID. If it starts with `Qm`, it's `base58btc` and is `CIDv0`. If it starts with `b` it's `base32` and is `CIDv1`.",
     correct: true,
-    feedback: 'That\'s correct!'
+    feedback: "That's correct!"
   }
 ]
 

--- a/src/tutorials/0006-anatomy-of-a-cid/06.js
+++ b/src/tutorials/0006-anatomy-of-a-cid/06.js
@@ -1,20 +1,22 @@
-const question = 'If we have two different CIDs pointing to the same content, doesn\'t that break the "uniqueness" rule specified in the first lesson?'
+/* eslint quotes: ["error", "double"]  */
+
+const question = "If we have two different CIDs pointing to the same content, doesn't that break the 'uniqueness' rule specified in the first lesson?"
 
 const choices = [
   {
-    answer: 'Yes, because CIDv0 and CIDv1 are not compatible.',
+    answer: "Yes, because CIDv0 and CIDv1 are not compatible.",
     correct: false,
-    feedback: 'Actually, all CIDs in Version 0 can be converted to be represented in Version 1, and both versions would have something important in common.'
+    feedback: "Actually, all CIDs in Version 0 can be converted to be represented in Version 1, and both versions would have something important in common."
   },
   {
-    answer: 'No, because the two CIDs are just two different version representations of the same hash. The hash is still unique to the data it represents.',
+    answer: "No, because the two CIDs are just two different version representations of the same hash. The hash is still unique to the data it represents.",
     correct: true,
-    feedback: 'That\'s correct!'
+    feedback: "That's correct!"
   },
   {
-    answer: 'Yes, because the hashes are no longer unique.',
+    answer: "Yes, because the hashes are no longer unique.",
     correct: false,
-    feedback: 'The relationship between the CID and the hash isn\'t unique, but what about the relationship between the hash and the data it represents?'
+    feedback: "The relationship between the CID and the hash isn't unique, but what about the relationship between the hash and the data it represents?"
   }
 ]
 

--- a/src/tutorials/boilerplates/boilerplate-multiple-choice.js
+++ b/src/tutorials/boilerplates/boilerplate-multiple-choice.js
@@ -1,3 +1,5 @@
+/* eslint quotes: ["error", "double"]  */
+
 // Question must be a string
 const question = "What's the meaning of life, the universe, and everything?"
 
@@ -6,17 +8,17 @@ const question = "What's the meaning of life, the universe, and everything?"
 // Only one answer can be correct.
 const choices = [
   {
-    answer: 'Some correct answer.',
+    answer: "Some correct answer.",
     correct: true,
-    feedback: 'Great job!'
+    feedback: "Great job!"
   },
   {
-    answer: 'Some incorrect answer',
+    answer: "Some incorrect answer",
     correct: false,
     feedback: "Oops. Here's some clue about why that answer is wrong."
   },
   {
-    answer: 'Some incorrect answer',
+    answer: "Some incorrect answer",
     correct: false,
     feedback: "Sorry, here's some clue about why that answer is wrong."
   }


### PR DESCRIPTION
@terichadbourne mentioned that having single quotes in the boilerplate makes it hard to write content because most of the times we'll need to use apostrophes, so let's switch them to double quotes and force this through file specific config.