### PR TITLE
assign project hashtags and handles

### DIFF
--- a/src/components/callouts/TutorialCompletion.vue
+++ b/src/components/callouts/TutorialCompletion.vue
@@ -29,7 +29,7 @@ export default {
       let href = 'https://twitter.com/intent/tweet?'
       href += `text=I just completed the ${this.tutorial.title} tutorial at @ProtoSchool!`
       href += `&url=${encodeURIComponent(getTutorialFullUrl(this.tutorial.formattedId))}`
-      href += `&hashtags=${this.tutorial.project.name}`
+      href += `&hashtags=${this.tutorial.project.twitterHashtag}`
 
       return href
     }

--- a/src/static/projects.json
+++ b/src/static/projects.json
@@ -2,31 +2,42 @@
   {
     "id": "ipfs",
     "name": "IPFS",
-    "url": "https://ipfs.io"
+    "url": "https://ipfs.io",
+    "twitterHashtag": "IPFS",
+    "twitterHandle": "IPFS"
   },
   {
     "id": "ipld",
     "name": "IPLD",
-    "url": "https://ipld.io"
+    "url": "https://ipld.io",
+    "twitterHashtag": "IPLD",
+    "twitterHandle": "IPLDbot"
   },
   {
     "id": "libp2p",
     "name": "libp2p",
-    "url": "https://libp2p.io"
+    "url": "https://libp2p.io",
+    "twitterHashtag": "libp2p",
+    "twitterHandle": "libp2p"
   },
   {
     "id": "multiformats",
     "name": "Multiformats",
-    "url": "https://multiformats.io"
+    "url": "https://multiformats.io",
+    "twitterHashtag": "Multiformats",
+    "twitterHandle": "Multiformats"
   },
   {
     "id": "filecoin",
     "name": "Filecoin",
-    "url": "https://filecoin.io"
+    "url": "https://filecoin.io",
+    "twitterHashtag": "Filecoin",
+    "twitterHandle": "Filecoin"
   },
   {
     "id": "dweb",
     "name": "DWeb Concepts",
-    "url": "https://proto.school"
+    "url": "https://proto.school",
+    "twitterHashtag": "DWeb"
   }
 ]


### PR DESCRIPTION
Closes #467 

This PR assigns `twitterHashtag` (used) and `twitterHandle` (where applicable, future-proofing) values in `projects.json`, then uses the `twitterHashtag` in place of `name` when building a proposed tweet from the `TutorialCompletion` component. This avoids the challenge we were having with our new psuedo-project "DWeb Concepts."


![image](https://user-images.githubusercontent.com/19171465/86312613-1d38de00-bbf1-11ea-81b0-a05f6749bb7a.png)
