### PR TITLE
fix: paths to images should be absolute, not relative

### DIFF
--- a/DEVELOPING_TUTORIALS.md
+++ b/DEVELOPING_TUTORIALS.md
@@ -420,13 +420,13 @@ If you want to add images to your Markdown file, place them in the `public/tutor
 Then in your lesson Markdown file, you can either add the image with regular Markdown:
 
 ```
-![Description of the image](tutorial-assets/T0001L01-diagram.svg)
+![Description of the image](/tutorial-assets/T0001L01-diagram.svg)
 ```
 
 ...or with regular HTML, if you need to set the image size:
 
 ```html
-<img src="tutorial-assets/T0001L01-diagram.svg" width="300px" height="150px" />
+<img src="/tutorial-assets/T0001L01-diagram.svg" width="300px" height="150px" />
 ```
 
 

--- a/src/tutorials/0001-data-structures/05.md
+++ b/src/tutorials/0001-data-structures/05.md
@@ -54,7 +54,7 @@ these data structures backwards, from the leaf nodes on up to the root node.
 
 ## Directed Acyclic Graphs (DAG)
 
-![Directed Acycil Graphs](/tutorial-assets/T0001L01-dag.svg)
+![Directed Acyclic Graphs](/tutorial-assets/T0001L01-dag.svg)
 
 DAG is an acronym for [`Directed Acyclic Graph`](https://en.wikipedia.org/wiki/Directed_acyclic_graph). It's a fancy way of describing a
 specific kind of Merkle tree (hash tree) where different branches in the tree can point at other branches

--- a/src/tutorials/0001-data-structures/05.md
+++ b/src/tutorials/0001-data-structures/05.md
@@ -54,7 +54,7 @@ these data structures backwards, from the leaf nodes on up to the root node.
 
 ## Directed Acyclic Graphs (DAG)
 
-![Directed Acycil Graphs](tutorial-assets/T0001L01-dag.svg)
+![Directed Acycil Graphs](/tutorial-assets/T0001L01-dag.svg)
 
 DAG is an acronym for [`Directed Acyclic Graph`](https://en.wikipedia.org/wiki/Directed_acyclic_graph). It's a fancy way of describing a
 specific kind of Merkle tree (hash tree) where different branches in the tree can point at other branches

--- a/src/tutorials/0006-anatomy-of-a-cid/01.md
+++ b/src/tutorials/0006-anatomy-of-a-cid/01.md
@@ -13,7 +13,7 @@ For example, if we stored an image of an aardvark on the IPFS network, its CID w
 
 The first step to creating a CID is to transform the input data, using a **cryptographic algorithm** that maps input of arbitrary size (data or a file) to output of a fixed size. This transformation is known as **cryptographic hash digest** or simply **hash**.
 
-![Cryptographic Algorithm infographic](tutorial-assets/T0006L01-crypto-algo-256.png)
+![Cryptographic Algorithm infographic](/tutorial-assets/T0006L01-crypto-algo-256.png)
 
 The **cryptographic algorithm** used must generate hashes that have the following characteristics:
 

--- a/src/tutorials/0006-anatomy-of-a-cid/02.md
+++ b/src/tutorials/0006-anatomy-of-a-cid/02.md
@@ -5,7 +5,7 @@
 
 Occasionally, a hashing algorithm may be proven to be insecure, meaning it no longer complies with the characteristics that we defined earlier. This has already happened with `sha1`. With time, other algorithms may prove to be insufficient for content addressing in IPFS and other distributed information systems. For this reason, and in order to support multiple cryptographic algorithms, **we need to be able to know which algorithm was used to generate the hash** of specific content.
 
-![What is the hashing algorithm used in a hash?](tutorial-assets/T0006L02-what-algo.jpg)
+![What is the hashing algorithm used in a hash?](/tutorial-assets/T0006L02-what-algo.jpg)
 
 So how can we do this?
 To support multiple hashing algorithms, we use **multihash**.
@@ -17,7 +17,7 @@ A [**multihash**](https://multiformats.io/multihash/) is a self-describing hash 
 
 Multihashes follow the `TLV` pattern (`type-length-value`). Essentially, the "original hash" is prefixed with the `type` of hashing algorithm applied and the `length` of the hash.
 
-![Multihash format](tutorial-assets/T0006L02-multihash.jpg)
+![Multihash format](/tutorial-assets/T0006L02-multihash.jpg)
 
  - `type`: identifier of the **cryptographic algorithm** used to generate the hash (e.g. the identifier of `sha2-256` would be `18` - `0x12` in hexadecimal) - see the [multicodec table](https://github.com/multiformats/multicodec/blob/master/table.csv) for all the identifiers
  - `length`: the actual **length** of the hash (using `sha2-256` it would be `256` bits, which equates to 32 bytes)

--- a/src/tutorials/0006-anatomy-of-a-cid/03.md
+++ b/src/tutorials/0006-anatomy-of-a-cid/03.md
@@ -12,7 +12,7 @@ It could be encoded with CBOR, Protobuf, plain JSON, etc. To solve this issue, `
 
 The **multicodec prefix** indicates which encoding was used on the data.
 
-![Multicodec Prefix](tutorial-assets/T0006L03-multicodec.png)
+![Multicodec Prefix](/tutorial-assets/T0006L03-multicodec.png)
 
 Multicodec supports many different types of encoding, and each has its own short codec identifier, as shown in the [complete table](https://github.com/multiformats/multicodec/blob/master/table.csv).
 

--- a/src/tutorials/0006-anatomy-of-a-cid/04.md
+++ b/src/tutorials/0006-anatomy-of-a-cid/04.md
@@ -9,7 +9,7 @@ Now that we've added a multicodec, our Version 1 CID contains the following fiel
 
 But, if you remember from the previous lessons, Version 0 CIDs only contain the `<multihash-*>` parts, so how can we distinguish between different versions of CIDs? You guessed it, more prefixes!
 
-![Version Prefix](tutorial-assets/T0006L04-version-prefix.png)
+![Version Prefix](/tutorial-assets/T0006L04-version-prefix.png)
 
 So now our CID looks like this:
 

--- a/src/tutorials/0006-anatomy-of-a-cid/05.md
+++ b/src/tutorials/0006-anatomy-of-a-cid/05.md
@@ -19,11 +19,11 @@ In `CIDv0`, hashes are **always** encoded with `base58btc`. _Always_. This means
 
 [Multibase](https://github.com/multiformats/multibase) prefixes, which represent the base encoding used when converting CIDs between string and binary formats, are **only used in the string form of the CID**:
 
-![Multibase Prefix](tutorial-assets/T0006L05-multibase-prefix.png)
+![Multibase Prefix](/tutorial-assets/T0006L05-multibase-prefix.png)
 
 Let's examine two examples of CIDs in their string form:
 
-![String form examples](tutorial-assets/T0006L05-string-form.png)
+![String form examples](/tutorial-assets/T0006L05-string-form.png)
 
 We know the first one is a `CIDv0` because it starts with `Qm...`. All hashes that start with `Qm` can safely be interpreted as `base58btc` as a CID of Version 0.
 

--- a/src/tutorials/0006-anatomy-of-a-cid/06.md
+++ b/src/tutorials/0006-anatomy-of-a-cid/06.md
@@ -13,7 +13,7 @@ In this final lesson we will take a look at some results from this tool using bo
 
 This first example is a version 1 CID.
 
-![Results from the CID Inspector tool for the first example](tutorial-assets/T0006L06-example-1.jpg)
+![Results from the CID Inspector tool for the first example](/tutorial-assets/T0006L06-example-1.jpg)
 
 Looking at the results from the CID Inspector tool we can see several parts that the tool was able to parse for us:
 
@@ -28,7 +28,7 @@ From the "Human Readable CID" breakdown, we can see that the original hash of th
 
 [`QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR`](https://cid.ipfs.io/#QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR)
 
-![Results from the CID Inspector tool for the first example](tutorial-assets/T0006L06-example-2.jpg)
+![Results from the CID Inspector tool for the first example](/tutorial-assets/T0006L06-example-2.jpg)
 
 This Version 0 CID shows some different results: both the `multibase` and the `multicodec` are listed as "implicit".
 Since Version 0 CIDs did not have those prefixes, they are always assumed to be `base58btc` and `dag-pb` respectively.


### PR DESCRIPTION
Images are not loading in the new netlify build: https://protoschool-prod.netlify.app/data-structures/05

The paths to the images need to be absolute.