### PR TITLE
fix: remove 404 tests because they are testing server functionality

### DIFF
--- a/cypress/integration/redirects.spec.js
+++ b/cypress/integration/redirects.spec.js
@@ -4,13 +4,6 @@ describe('REDIRECTS', () => {
     cy.location('pathname').should('eq', redirect || path)
   }
 
-  it('404 redirect', () => {
-    cy.visit('/unknown-path', { failOnStatusCode: false })
-    cy.location('pathname').should('eq', '/404')
-    cy.visit('/unknown-path/02', { failOnStatusCode: false })
-    cy.location('pathname').should('eq', '/404')
-  })
-
   it('should redirect the old hash urls to the new paths', () => {
     assertHashRouteRedirect('/tutorials')
     assertHashRouteRedirect('/news')


### PR DESCRIPTION
We need to remove them otherwise the tests might fail on local machines, but work on CI, even though we are not testing against the correct server.