### PR TITLE
fix: do not use trailing slashes in local storage item ids

### DIFF
--- a/cypress/integration/tutorials.spec.js
+++ b/cypress/integration/tutorials.spec.js
@@ -486,3 +486,47 @@ function advanceThroughLessons (tutorialId) {
     }) // end this lesson
   }) // end loop through standard lessons, landing on resources page
 } // end advanceThroughLessons
+
+describe('SHOULD ADVANCE LESSONS WITH TRAILING SLASHES', () => {
+  it('should advance text lessons', () => {
+    cy.visit('/data-structures/01/')
+    cy.get(`[data-cy=next-lesson-text]`).should('be.visible').and('not.be.disabled').click()
+    cy.location('pathname').should('eq', '/data-structures/02')
+  })
+
+  it('should advance multiple choice lessons', () => {
+    cy.visit('/anatomy-of-a-cid/01/')
+    cy.get('[data-cy=choice]').eq(1).click()
+    cy.get(`[data-cy=next-lesson-mult-choice]`).should('be.visible').and('not.be.disabled').click()
+    cy.location('pathname').should('eq', '/anatomy-of-a-cid/02')
+  })
+
+  it('should advance code challenge lessons', () => {
+    cy.visit('/basics/01/')
+    cy.get('[data-cy=code-editor-ready]').should('be.visible') // wait for editor to be updated
+    cy.get(`[data-cy=next-lesson-code]`).should('not.be.visible')
+    cy.get('[data-cy=replace-with-solution]').click({ force: true })
+    cy.get('[data-cy=submit-answer]').click()
+    cy.get(`[data-cy=progress-in-progress]`).should('be.visible')
+    cy.get(`[data-cy=progress-icon-in-progress]`).should('be.visible')
+    cy.get(`[data-cy=next-lesson-code]`).should('be.visible').click()
+    cy.location('pathname').should('eq', '/basics/02')
+  })
+
+  it('should advance file upload code challenge lessons', () => {
+    cy.visit('/mutable-file-system/04/')
+    cy.get('[data-cy=code-editor-ready]').should('be.visible') // wait for editor to be updated
+
+    const fileName = 'favicon.png'
+    cy.fixture(fileName).then(fileContent => {
+      cy.get('[data-cy=file-upload]').upload({ fileContent, fileName, mimeType: 'image/png' })
+    })
+    cy.get(`[data-cy=next-lesson-code]`).should('not.be.visible')
+    cy.get('[data-cy=replace-with-solution]').click({ force: true })
+    cy.get('[data-cy=submit-answer]').click()
+    cy.get(`[data-cy=progress-in-progress]`).should('be.visible')
+    cy.get(`[data-cy=progress-icon-in-progress]`).should('be.visible')
+    cy.get(`[data-cy=next-lesson-code]`).should('be.visible').click()
+    cy.location('pathname').should('eq', '/mutable-file-system/05')
+  })
+})

--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -227,12 +227,14 @@ export default {
     createTestTree: Boolean
   },
   data: self => {
+    const routePath = self.$route.path.endsWith('/') ? self.$route.path.slice(0, self.$route.path.length - 1) : self.$route.path
+
     return {
       isSubmitting: false,
-      lessonPassed: !!localStorage['passed' + self.$route.path],
-      lessonKey: 'passed' + self.$route.path,
-      cacheKey: 'cached' + self.$route.path,
-      cachedCode: !!localStorage['cached' + self.$route.path],
+      lessonPassed: !!localStorage['passed' + routePath],
+      lessonKey: 'passed' + routePath,
+      cacheKey: 'cached' + routePath,
+      cachedCode: !!localStorage['cached' + routePath],
       editorCode: localStorage[self.cacheKey] || self.code || self.defaultCode,
       viewSolution: false,
       cachedStateMsg: '',
@@ -244,11 +246,14 @@ export default {
       isMultipleChoiceLesson: self.isMultipleChoiceLesson,
       uploadedFiles: window.uploadedFiles || false,
       choice: localStorage[self.cacheKey] || '',
-      cachedChoice: !!localStorage['cached' + self.$route.path],
+      cachedChoice: !!localStorage['cached' + routePath],
       output: self.output
     }
   },
   computed: {
+    routePath: function () {
+      return this.$route.path.endsWith('/') ? this.$route.path.slice(0, this.$route.path.length - 1) : this.$route.path
+    },
     tutorial: function () {
       return getTutorialByUrl(this.$route.params.tutorialUrl)
     },
@@ -268,7 +273,7 @@ export default {
       return this.tutorial.lessons.length
     },
     nextLessonIsResources: function () {
-      const basePath = this.$route.path.slice(0, -2)
+      const basePath = this.routePath.slice(0, -2)
       const hasResources = this.$router.resolve(basePath + 'resources').route.name !== '404'
       return this.lessonId === this.lessonsInTutorial && hasResources
     },
@@ -276,7 +281,7 @@ export default {
       return {
         tutorial: this.tutorial.shortTitle,
         lessonNumber: this.isResources ? 'resources' : this.lessonId,
-        path: this.$route.path
+        path: this.routePath
       }
     }
   },
@@ -561,11 +566,10 @@ export default {
           this.updateTutorialState()
         }
       }
-      const current = this.lessonId
 
       const next = this.nextLessonIsResources
-        ? 'resources'
-        : (parseInt(current) + 1).toString().padStart(2, '0')
+        ? `/${this.tutorial.url}/resources`
+        : this.tutorial.lessons[this.tutorial.lessons.findIndex(lesson => lesson === this.lesson) + 1].url
 
       this.$router.push({ path: next })
     },

--- a/src/utils/tutorials.js
+++ b/src/utils/tutorials.js
@@ -47,16 +47,19 @@ for (const tutorialId in tutorials) {
 // TODO Move this to a build script in the future to avoid heavy processing on the client.
 // This will only become a problem when the number of tutorials and lessons increases
 export function getTutorialLessons (tutorial, lessons = [], lessonNumber = 1) {
-  const lessonFilePrefix = `${tutorial.formattedId}-${tutorial.url}/${lessonNumber.toString().padStart(2, 0)}`
+  const formattedId = lessonNumber.toString().padStart(2, 0)
+  const lessonFilePrefix = `${tutorial.formattedId}-${tutorial.url}/${formattedId}`
 
   let lessonMd
   let lesson
 
   try {
     lessonMd = require(`../tutorials/${lessonFilePrefix}.md`)
+
     lesson = {
       id: lessonNumber,
-      formattedId: lessonNumber.toString().padStart(2, 0),
+      formattedId,
+      url: `/${tutorial.url}/${formattedId}`,
       ...marked(lessonMd).meta
     }
   } catch (error) {


### PR DESCRIPTION
Fixes #530

Any new progress with the trailing slash will not be taken into account, but previous progress without the slash will still be taken into account. I don't think this will be a problem since advancing any lesson was working, so effectively, no progress will be lost, but I thought I'd still mention it.