### PR TITLE
fix: document metadata was not updating between some pages

### DIFF
--- a/src/pages/Build.vue
+++ b/src/pages/Build.vue
@@ -83,6 +83,8 @@ export default {
   components: {
     Header
   },
-  head: head()
+  head () {
+    return head()
+  }
 }
 </script>

--- a/src/pages/Contribute.vue
+++ b/src/pages/Contribute.vue
@@ -87,6 +87,8 @@ export default {
   components: {
     Header
   },
-  head: head()
+  head () {
+    return head()
+  }
 }
 </script>

--- a/src/pages/Events.vue
+++ b/src/pages/Events.vue
@@ -69,7 +69,9 @@ export default {
       this.viewAllPast = !this.viewAllPast
     }
   },
-  head: head()
+  head () {
+    return head()
+  }
 }
 
 </script>

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -65,6 +65,8 @@ export default {
   computed: {
     featuredTutorials: () => coursesList.featured.map(tutorialId => ({ ...tutorials[tutorialId], tutorialId }))
   },
-  head: head()
+  head () {
+    return head()
+  }
 }
 </script>

--- a/src/pages/Host.vue
+++ b/src/pages/Host.vue
@@ -96,6 +96,8 @@ export default {
   components: {
     Header
   },
-  head: head()
+  head () {
+    return head()
+  }
 }
 </script>

--- a/src/pages/News.vue
+++ b/src/pages/News.vue
@@ -55,7 +55,9 @@ export default {
       })
     }
   },
-  head: head()
+  head () {
+    return head()
+  }
 }
 </script>
 <style scoped>

--- a/src/pages/Tutorials.vue
+++ b/src/pages/Tutorials.vue
@@ -146,6 +146,8 @@ export default {
       this.setQueryParameter('code', this.showCodingTutorials)
     }
   },
-  head: head()
+  head () {
+    return head()
+  }
 }
 </script>

--- a/src/utils/head/index.js
+++ b/src/utils/head/index.js
@@ -17,7 +17,9 @@
   import head from '../utils/head
 
   export default {
-    head: head()
+    head() {
+      return head()
+    }
   }
   </script>
   ```


### PR DESCRIPTION
`head` was not being called on every page change.

Change on some pages from

```js
head: head()
```

to 
```js
head() {
    return head()
}

Closes #526 