### PR TITLE
fix: remove trailing slash on vue router to make countly data consistent

### DIFF
--- a/cypress/integration/redirects.spec.js
+++ b/cypress/integration/redirects.spec.js
@@ -16,7 +16,7 @@ describe('REDIRECTS', () => {
     assertHashRouteRedirect('/data-structures/resources')
     assertHashRouteRedirect('/data-structures/01')
     assertHashRouteRedirect('/basics')
-    assertHashRouteRedirect('/basics/')
+    assertHashRouteRedirect('/basics/', '/basics')
     assertHashRouteRedirect('/basics/resources')
     assertHashRouteRedirect('/basics/02')
     assertHashRouteRedirect('/unknown-route', '/404')

--- a/src/router.js
+++ b/src/router.js
@@ -47,4 +47,13 @@ router.afterEach((to) => {
   window.Countly.q.push(['track_pageview', to.path])
 })
 
+router.beforeEach((to, from, next) => {
+  // Remove trailing slash on client side only
+  if (to.path !== '/' && to.path.endsWith('/')) {
+    next({ path: to.path.substring(0, to.path.length - 1), replace: true })
+  } else {
+    next()
+  }
+})
+
 export default router

--- a/src/routes.js
+++ b/src/routes.js
@@ -73,7 +73,7 @@ function statics () {
 // Redirects that need to return a 301 status code need to be configured in the server as well
 function redirects () {
   return [
-    { path: '/chapters/', redirect: '/events' }
+    { path: '/chapters/', redirect: '/events/' }
   ].map(route => ({ ...route, type: TYPES.REDIRECT })).map(addSitemapLoc)
 }
 
@@ -81,7 +81,7 @@ function redirects () {
 function errors () {
   return [
     {
-      path: '/404',
+      path: '/404/',
       name: '404',
       component: () => import(/* webpackChunkName: "error" */ './pages/NotFound')
     }


### PR DESCRIPTION
I noticed that in countly we were getting a lot of data points with inconsistent urls that include trailing slashes and others that don't.
Examples:

 - Events: https://countly.proto.school/dashboard#/5d25fd49db14b4435e4432e2/analytics/events/key/tutorialFeedbackSurveyCompleted
- Page Views (notice the `/data-structures` url has a duplicated entry with `/data-structures/`

![image](https://user-images.githubusercontent.com/2353186/92770361-cb02fe80-f391-11ea-99a2-e3b746029a93.png)


This PR will remove the trailing slash on client-slide. Netlify/Fleek trailing slash redirect will not be affected and will still happen.

### How it works

By using `vue-router`'s `beforeEach` function, we can remove the trailing slash from window location if it's present, and only the client side will be affected.
So the redirect from Netlify/Fleek to add the trailing slash will still happen, but then `vue-router` kicks in and will remove it, so that our application state does not contain the trailing slash. Meaning Countly and other vue router accesses will be correct: no trailing slash.

This fixes a lot of Countly events being logged incorrectly and also prevents future bugs that depend on the route.