### PR TITLE
fix: add query to trailing slash removal logic

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -50,7 +50,7 @@ router.afterEach((to) => {
 router.beforeEach((to, from, next) => {
   // Remove trailing slash on client side only
   if (to.path !== '/' && to.path.endsWith('/')) {
-    next({ path: to.path.substring(0, to.path.length - 1), replace: true })
+    next({ path: to.path.substring(0, to.path.length - 1), replace: true, query: to.query })
   } else {
     next()
   }


### PR DESCRIPTION
With the latest fix, we are now removing the trailing slash, but also removing the query parameters.

Example: https://proto.school/tutorials/?code=true&course=ipfs would redirect to https://proto.school/tutorials

This PR fixes this. Keeps the redirect that removes the trailing slash, keeping the query parameters if present.