### PR TITLE
fix: force page refresh on ChunkLoadError

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -47,12 +47,31 @@ router.afterEach((to) => {
   window.Countly.q.push(['track_pageview', to.path])
 })
 
+// To be used in the onError handler
+let nextRoute = null
+
 router.beforeEach((to, from, next) => {
+  nextRoute = { ...to }
+
   // Remove trailing slash on client side only
   if (to.path !== '/' && to.path.endsWith('/')) {
     next({ path: to.path.substring(0, to.path.length - 1), replace: true, query: to.query })
   } else {
     next()
+  }
+})
+
+router.onError(error => {
+  // https://github.com/ProtoSchool/protoschool.github.io/issues/555
+  // When a user comes back to a tab with ProtoSchool open after a deployment,
+  // they might get this ChunkLoadError error
+  // because the chunk's name does not exist anymore (because of cache busting hashes in the filenames).
+  // When it happens, we can force the page to reload and the new files will
+  // fetched instead.
+  if (error.name === 'ChunkLoadError') {
+    console.warn('Failed to load chunk due to new version of the website published - will reload page')
+
+    window.location.pathname = nextRoute ? nextRoute.path : window.location.pathname
   }
 })
 


### PR DESCRIPTION
When a user comes back to a tab with ProtoSchool open after a deployment, they might get this ChunkLoadError error because the chunk's name does not exist anymore (because of cache busting hashes in the filenames).

The fix for this is to force the browser to reload.
In addition to that, we are navigating the user to the route they wanted to change to, so that instead of simply reloading the page, the user actually navigates to the correct page.

Closes #555 

### Refs:

 - https://dev.to/ianwalter/fixing-chunkloaderror-3791

### Steps to test this PR:

1. run prod build and server it: `npm run build && npm run cy:serve`
2. open localhost:3000 without cache enabled (dev tools > network > disable cache: on)
3. change content in the Events page. Open `src/pages/Events.vue` file, and change the content (add `test` anywhere in the template)
4. close and run prod build again: `npm run build && npm run cy:serve`
5. without refreshing, click on the events link in the navigation
6. the website should reload and land on the `/events` page