### PR TITLE
fix: make sure the document, body and its children adapt to the viewport in height

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,17 +16,48 @@ export default {
 
 <style>
 
-html {
-  overflow-y: scroll;
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
 }
 
-html, body {
-  min-height: 100%;
+/*
+   Document
+
+   1. Stretch <html> stretch to fill our screen height
+   2. Make children of html (body) occupy at least 100% of the screen
+   3. Viewport is scalable and occupies at least 320px (iPhone SE)
+*/
+
+html {
+    min-width: 25em;
+    height: 0; /* 3 */
+    min-height: 100%; /* 1 */
+    display: flex; /* 2 */
+    flex-direction: column; /* 2 */
+}
+
+/*
+   Body & #app
+
+   1. Force scroll always to prevent scrollbars to appear/disappear based on the page contents
+   2. Make sure that we occupy 100% of our parent and allow our child elements to do the same
+   3. Disable rubber band scrolling
+*/
+
+body {
+    overflow-y: scroll; /* 1 */
+    display: flex; /* 2 */
+    flex: 1 0 auto; /* 2 */
+    flex-direction: column; /* 2 */
 }
 
 #app {
-  width: 100%;
-  height: 100%;
+  display: flex; /* 2 */
+  flex: 1 0 auto; /* 2 */
+  flex-direction: column; /* 2 */
+
   font-family: 'Avenir', Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -34,9 +65,9 @@ html, body {
 }
 
 #app > div {
-  min-height: 100%;
-  display: flex;
-  flex-direction: column;
+  display: flex; /* 2 */
+  flex: 1 0 auto; /* 2 */
+  flex-direction: column; /* 2 */
 }
 
 pre {


### PR DESCRIPTION
ATM the content is not occupying the full viewport and the footer on the lesson pages does not stick to the bottom of the viewport on larger screens:

![image](https://user-images.githubusercontent.com/2353186/100383734-42057600-3016-11eb-9f7e-005493e6ef6d.png)

To fix this I adapted the layout styles from [next-with-moxy](https://github.com/moxystudio/next-with-moxy) to fix this issue thoroughly across browsers and devices.


Adapted from https://github.com/moxystudio/next-with-moxy/blob/master/www/shared/styles/global/layout.css