### PR TITLE
fix: move tutorial completed badge (trophy) to the top

### DIFF
--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -17,7 +17,7 @@
         <h2 class="f6 mv0 fw2">{{tutorial.project.name}}</h2>
       </div>
       <div class="flex justify-between flex-row items-start mb1">
-        <div class="flex flex-row items-center mt1">
+        <div class="flex flex-row items-start mt1">
           <h1 class="ma0 f3 fw5">
             <template v-if="isLanding !== true">
               <router-link :to="landingLink" data-cy="tutorial-title">{{tutorial.title}}</router-link>


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/2353186/104054254-b0784f00-51e4-11eb-85ca-d41896c98fab.png)

After the fix:

![image](https://user-images.githubusercontent.com/2353186/104054294-bec66b00-51e4-11eb-9e5f-10befa101bb3.png)
