### PR TITLE
fix: show syntax error

### DIFF
--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -176,8 +176,8 @@ const _eval = async (text, ipfs, args = []) => {
   try {
     // eslint-disable-next-line
     fn = new Function(Object.keys(modules).join(','), text)
-  } catch (err) {
-    return new SyntaxError(err.message, err)
+  } catch (error) {
+    return new SyntaxError(error.message, error)
   }
 
   let result

--- a/src/components/Output.vue
+++ b/src/components/Output.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="pt2">
-    <div v-if="output.test.error"
-      class="lh-copy pv2 ph3 bg-red white"
-      v-html="parseData(`Error: ${output.test.error.message}`)"
-      >
-    </div>
+    <div v-if="output.test && (output.test instanceof Error || output.test.error)"
+      class="output-log lh-copy bg-red white"
+      v-html="parseData(`${output.test instanceof Error ? output.test : output.test.error}`)"
+    />
     <div
       v-if="output.test.fail"
       class="output-log lh-copy bg-red white"
       v-html="parseData(output.test.fail)"
-      data-cy="output-fail"/>
+      data-cy="output-fail"
+    />
     <div class="lh-copy bg-green white" v-if="output.test.success && lessonPassed">
       <span class="output-log" data-cy="output-success" v-html="parseData(output.test.success)" />
       <span v-if="output.test.cid">
@@ -52,6 +52,7 @@ export default {
     trackingData: Object
   },
   computed: {
+    Error: () => Error,
     exploreIpldUrl: function () {
       let cid = this.output.test && this.output.test.cid && this.output.test.cid.toString()
 

--- a/src/components/Validator.vue
+++ b/src/components/Validator.vue
@@ -113,7 +113,7 @@ export default {
     isMultipleChoiceLesson: Boolean,
     uploadedFiles: Array,
     lessonPassed: Boolean,
-    output: Object,
+    output: [Object, Error],
     isResources: Boolean,
     nextLessonIsResources: Boolean,
     lessonNumber: Number,


### PR DESCRIPTION
Addresses #596 partially.

Syntax errors were not being given as feedback in the `Output` component on a specific case.
Although, the monaco editor should show the syntax error feedback right from the start to avoid situations like these #596 where the user simply missed a comma.

Fixing the code editor is filed here: https://github.com/ProtoSchool/protoschool.github.io/issues/597

This PR only addresses the issue of no error feedback when submitting code with a syntax error.
