### PR TITLE
Use Regular File API in examples

### DIFF
--- a/src/tutorials/0005-regular-files-api/06.md
+++ b/src/tutorials/0005-regular-files-api/06.md
@@ -26,7 +26,7 @@ To iterate over all the values, we can use a `for await...of` loop:
 ```javascript
 const result = []
 
-for await (const resultPart of ipfs.files.ls('/catPics')) {
+for await (const resultPart of ipfs.ls('/catPics')) {
     result.push(resultPart)
 }
 
@@ -39,7 +39,7 @@ To make things easier, we can use the [`it-all`](https://www.npmjs.com/package/i
 // the all function comes from the it-all package
 // and is made globally available (just like ipfs) in our code challenges
 
-const result = await all(ipfs.files.ls('/catPics'))
+const result = await all(ipfs.ls('/catPics'))
 ```
 
 The `result` variable is now an array of objects, one for each file or directory found, structured like so:


### PR DESCRIPTION
The examples are using the MFS API, not the regular files API. This change switches them to the regular files API