### PR TITLE
fix: code block in mfs lesson 2 badly formatted

### DIFF
--- a/src/tutorials/0004-mutable-file-system/02.md
+++ b/src/tutorials/0004-mutable-file-system/02.md
@@ -15,7 +15,7 @@ When working with your IPFS node, you'll often want to check the status of a fil
 
 For example, to check the status of a directory called `stuff` located within our root directory ( `/` ), we could call the method like so:
 
-````javascript
+```javascript
 await ipfs.files.stat('/stuff')
 ```
 


### PR DESCRIPTION
Before: https://proto.school/mutable-file-system/02

<img width="901" alt="image" src="https://user-images.githubusercontent.com/2353186/131354928-9808e2f1-c4c5-4d82-b625-0bef5ef161f3.png">

After: https://bafybeigycb6u73t2hp7is7cuvabltbsovkf3yordcvzy27pisgjmctd6tq.on.fleek.co/mutable-file-system/02

<img width="784" alt="image" src="https://user-images.githubusercontent.com/2353186/131362637-85a900f0-72f7-458d-a093-9020dd38c8c9.png">

