### PR TITLE
set fixed domain for tweets

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,7 @@ export const tutorialRedirectModal = {
 export const MAILCHIMP_API_URL = process.env.VUE_APP_MAILCHIMP_API_URL
 export const MAILCHIMP_USER_ID = process.env.VUE_APP_MAILCHIMP_USER_ID
 export const MAILCHIMP_LIST_ID = process.env.VUE_APP_MAILCHIMP_LIST_ID
+export const DOMAIN = 'https://proto.school'
 
 export default {
   MAILCHIMP_API_URL,

--- a/src/utils/tutorials.js
+++ b/src/utils/tutorials.js
@@ -2,6 +2,7 @@ import moment from 'moment'
 
 import marked from './marked'
 import projects from './projects'
+import { DOMAIN } from '../config'
 
 // Load data from the window variable
 // This supports data overriding and custom SSR
@@ -127,7 +128,7 @@ export function getLesson (tutorialId, lessonId) {
 
 // returns URL for tutorial's landing page
 export function getTutorialFullUrl (tutorialId) {
-  return `${window.location.origin}/${tutorials[tutorialId].url}`
+  return `${DOMAIN}/${tutorials[tutorialId].url}`
 }
 
 export const states = {


### PR DESCRIPTION
This PR sets a fixed domain to be used in tweets rather than using data from the window (could be localhost, IPFS links, etc.), which had previously led to tweets with non-functional links such as: 

![image](https://user-images.githubusercontent.com/19171465/131873673-6d7c2c7a-2d64-497c-9c2c-228d2045671e.png)
