### PR TITLE
Specify the node type in tutorials/0002-basics/01

### DIFF
--- a/src/tutorials/0002-basics/01.md
+++ b/src/tutorials/0002-basics/01.md
@@ -1,5 +1,5 @@
 ---
-    title: "Create a node and return a Content Identifier (CID)"
+    title: "Create a DAG node and return a Content Identifier (CID)"
     type: "code"
 ---
 
@@ -7,7 +7,7 @@ In this tutorial we'll be exploring the [IPFS DAG API](https://github.com/ipfs/j
 objects in IPFS. (You can store more exciting things in IPFS, like your favorite
 cat GIF, but you'd need to use a different API for that.)
 
-You can create a new node by passing a data object into the [`ipfs.dag.put`](https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/DAG.md#ipfsdagputdagnode-options) method,
+You can create a new DAG node by passing a data object into the [`ipfs.dag.put`](https://github.com/ipfs/js-ipfs/blob/master/docs/core-api/DAG.md#ipfsdagputdagnode-options) method,
 which returns a Content Identifier (CID) for the newly created node.
 
 ```javascript


### PR DESCRIPTION
Because the word `node` is used mostly for IPFS nodes in other tutorials but in this tutorial it means a DAG node.